### PR TITLE
feat: refactor to update vaarious dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0
+          toolchain: 1.79.0
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v2
@@ -35,7 +35,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0
+          toolchain: 1.79.0
           profile: minimal
           override: true
           components: rustfmt
@@ -55,7 +55,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0
+          toolchain: 1.79.0
           profile: minimal
           override: true
           components: clippy
@@ -75,7 +75,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.71.0
+          toolchain: 1.79.0
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -179,5 +179,6 @@
             "language": "markdown",
             "scheme": "file"
         }
-    ]
+    ],
+    "rust-analyzer.check.command": "clippy"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,12 +1481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,30 +2619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "manas_server_single_fs_noauth"
-version = "0.1.0"
-dependencies = [
- "manas_server",
- "tokio",
-]
-
-[[package]]
-name = "manas_server_single_fs_wac"
-version = "0.1.0"
-dependencies = [
- "manas_server",
- "tokio",
-]
-
-[[package]]
-name = "manas_server_single_s3_wac"
-version = "0.1.0"
-dependencies = [
- "manas_server",
- "tokio",
-]
-
-[[package]]
 name = "manas_space"
 version = "0.1.0"
 dependencies = [
@@ -2955,16 +2925,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -4981,7 +4941,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -128,47 +128,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -176,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "anymap2"
@@ -188,9 +189,9 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayvec"
@@ -200,9 +201,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-compat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -222,11 +223,13 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.8.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
  "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -237,13 +240,13 @@ checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -265,25 +268,25 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum-server"
@@ -307,11 +310,11 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a6197b2120bb2185a267f6515038558b019e92b832bb0320e96d66268dcf9"
+checksum = "d67782c3f868daa71d3533538e98a8e13713231969def7536e8039606fc46bf0"
 dependencies = [
- "fastrand 1.9.0",
+ "fastrand",
  "futures-core",
  "pin-project",
  "tokio",
@@ -319,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -343,6 +346,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -373,9 +382,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -409,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -419,15 +428,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
  "syn_derive",
 ]
 
@@ -446,15 +455,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -463,20 +472,14 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "bytecount"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "byteorder"
@@ -486,18 +489,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "canonical_json"
@@ -522,28 +516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,12 +526,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"
@@ -569,15 +538,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -585,7 +554,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -609,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -619,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -631,27 +600,36 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "config"
@@ -674,9 +652,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -731,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -749,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -793,16 +771,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -816,14 +793,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.5"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -831,27 +808,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.5"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.5"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -861,7 +838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -875,9 +852,9 @@ checksum = "5440d1dc8ea7cae44cda3c64568db29bfa2434aba51ae66a50c00488841a65a3"
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -907,15 +884,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -963,7 +940,7 @@ dependencies = [
 name = "dpop"
 version = "0.1.1"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "canonical_json",
  "claims",
@@ -986,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "dyn_problem"
@@ -1019,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "ecow"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ea5e3f9cda726431da9d1a8d5a29785d544b31e98e1ca7a210906244002e02"
+checksum = "54bfbb1708988623190a6c4dbedaeaf0f53c20c6395abd6a01feb327b3146f4b"
 
 [[package]]
 name = "ed25519"
@@ -1035,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1050,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -1077,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1096,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1115,43 +1092,40 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
+name = "event-listener-strategy"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "instant",
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -1165,15 +1139,15 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flagset"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
 name = "fnv"
@@ -1273,7 +1247,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1290,9 +1264,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1335,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1348,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -1364,14 +1338,14 @@ checksum = "b0e085ded9f1267c32176b40921b9754c474f7dd96f7e808d4a982e48aa1e854"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -1392,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1402,7 +1376,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.2",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -1411,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "5.1.0"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab283476b99e66691dee3f1640fea91487a8d81f50fb5ecc75538f8f8879a1e4"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
 dependencies = [
  "log",
  "pest",
@@ -1429,7 +1403,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1438,14 +1412,14 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "headers"
@@ -1453,7 +1427,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "headers-core",
  "http",
@@ -1473,15 +1447,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1518,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1664,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1682,9 +1656,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1789,12 +1763,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1806,15 +1780,6 @@ checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1835,13 +1800,19 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
+checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
 dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1854,15 +1825,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1998,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "json-number"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280f53da10842ffc42737ac8a6f2c14ced71f950de1cdb6765264a2eb1100cc5"
+checksum = "4c54d19ae7e6fc83aafa649707655a9a0ac956a0f62793bde4cfd193b0693fdf"
 dependencies = [
  "lexical",
  "ryu-js",
@@ -2027,11 +1998,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.2.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "js-sys",
  "pem",
  "ring",
@@ -2057,11 +2028,11 @@ checksum = "ed60c85f254d6ae8450cec15eedd921efbc4d1bdf6fcf6202b9a58b403f6f805"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -2139,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
@@ -2151,9 +2122,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litrs"
@@ -2163,9 +2134,9 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2195,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "manas"
@@ -2616,7 +2587,7 @@ dependencies = [
  "serde_json",
  "sophia_api",
  "sophia_turtle",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2679,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -2691,9 +2662,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -2707,18 +2678,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -2727,21 +2698,21 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1911e88d5831f748a4097a43862d129e3c6fca831eecac9b8db6d01d93c9de2"
+checksum = "9e0d88686dc561d743b40de8269b26eaf0dc58781bde087b0984646602021d08"
 dependencies = [
  "async-lock",
  "async-trait",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
+ "event-listener",
  "futures-util",
  "once_cell",
  "parking_lot",
  "quanta",
  "rustc_version",
- "skeptic",
  "smallvec",
  "tagptr",
  "thiserror",
@@ -2773,11 +2744,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -2811,11 +2781,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2846,19 +2815,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2867,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -2887,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -2911,9 +2879,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendal"
@@ -2924,7 +2892,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "flagset",
@@ -2947,11 +2915,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2968,7 +2936,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2979,9 +2947,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -2991,12 +2959,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3007,15 +2975,18 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oxilangtag"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d91edf4fbb970279443471345a4e8c491bf05bb283b3e6c88e4e606fd8c181b"
+checksum = "23f3f87617a86af77fa3691e6350483e7154c2ead9f1261b75130e21ca0f8acb"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "oxiri"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb175ec8981211357b7b379869c2f8d555881c55ea62311428ec0de46d89bd5c"
+checksum = "d05417ee46e2eb40dd9d590b4d67fc2408208b3a48a6b7f71d2bc1d7ce12a3e0"
 
 [[package]]
 name = "p256"
@@ -3042,10 +3013,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
+name = "parking"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3053,28 +3030,38 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pct-str"
@@ -3087,11 +3074,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -3118,9 +3105,9 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3129,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3139,22 +3126,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
@@ -3169,7 +3156,7 @@ checksum = "52cccdaffd2f361b4b4eb70b4249bd71d89bb66cb84b7f76483ecd1640c543ce"
 dependencies = [
  "aes-gcm",
  "aes-kw",
- "base64",
+ "base64 0.21.7",
  "cbc",
  "digest",
  "ed25519-dalek",
@@ -3222,7 +3209,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c5f20f71a68499ff32310f418a6fad8816eac1a2859ed3f0c5c741389dd6208"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "num-bigint-dig",
  "oid",
  "picky-asn1",
@@ -3233,29 +3220,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -3281,32 +3268,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core",
  "spki",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
-
-[[package]]
-name = "platforms"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "polyval"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3350,7 +3348,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -3379,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -3407,21 +3405,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.4.2",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quanta"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -3463,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -3517,11 +3504,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.1"
+version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3619,23 +3606,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -3649,13 +3636,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -3666,34 +3653,34 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "relative-path"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "reqsign"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed08ac3aa0676637644b1b892202f1ae789c28c15ebfa906128d111ae8086062"
+checksum = "43e319d9de9ff4d941abf4ac718897118b0fe04577ea3f8e0f5788971784eef5"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "chrono",
  "form_urlencoded",
  "getrandom",
@@ -3718,11 +3705,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3766,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3797,16 +3784,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3840,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -3858,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3881,6 +3869,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core",
+ "sha2",
  "signature",
  "spki",
  "subtle",
@@ -3912,15 +3901,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.48",
+ "syn 2.0.68",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rust-embed"
-version = "8.2.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f"
+checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -3929,22 +3918,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.2.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16"
+checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.48",
+ "syn 2.0.68",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.2.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665"
+checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
 dependencies = [
  "sha2",
  "walkdir",
@@ -3962,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.2"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755392e1a2f77afd95580d3f0d0e94ac83eeeb7167552c9b5bca549e61a94d83"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3978,9 +3967,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -3993,11 +3982,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4006,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
@@ -4034,7 +4023,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4049,9 +4038,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "ryu-js"
@@ -4064,6 +4053,15 @@ name = "ryu_floating_decimal"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "700de91d5fd6091442d00fdd9ee790af6d4f0f480562b0f5a1e8f59e90aafe73"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -4088,6 +4086,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sct"
@@ -4121,11 +4130,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4134,9 +4143,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4144,47 +4153,44 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
-dependencies = [
- "serde",
-]
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -4193,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -4214,16 +4220,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.6.0"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0ed1662c5a68664f45b76d18deb0e234aff37207086803165c961eb695e981"
+checksum = "e73139bc5ec2d45e6c5fd85be5a46949c1c39a4c18e56915f5eb4c12f975e377"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.2.6",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -4231,23 +4238,23 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.6.0"
+version = "3.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568577ff0ef47b879f736cd66740e022f3672788cdf002a05a4e609ea5a6fb15"
+checksum = "b80d3d6b56b64335c0180e5ffde23b3c5e08c14c585b51a15bd0e95393f46703"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.31"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -4324,21 +4331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,18 +4350,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4505,12 +4497,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -4542,15 +4528,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4565,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4583,7 +4569,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4636,13 +4622,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
- "redox_syscall",
+ "fastrand",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -4655,29 +4640,29 @@ checksum = "7f8b59b4da1c1717deaf1de80f0179a9d8b4ac91c986d5fd9f4a8ff177b84049"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4685,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.33"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b24b79b7a07f10209f19e683ca1e289d80b1e76ffa8c2b779718566a083679"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -4706,9 +4691,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4725,9 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4740,9 +4725,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4757,13 +4742,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4788,9 +4773,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4799,35 +4784,34 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -4838,11 +4822,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.2.6",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+dependencies = [
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -4867,7 +4862,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4912,7 +4907,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4967,11 +4962,10 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
- "lazy_static",
  "tracing-core",
  "tracing-subscriber",
  "tracing-test-macro",
@@ -4979,20 +4973,19 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "lazy_static",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "triomphe"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 
 [[package]]
 name = "try-lock"
@@ -5043,9 +5036,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -5062,9 +5055,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -5099,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5117,15 +5110,15 @@ checksum = "ca61eb27fa339aa08826a29f03e87b99b4d8f0fc2255306fd266bb1b6a9de498"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "serde",
@@ -5145,9 +5138,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec1"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bda7c41ca331fe9a1c278a9e7ee055f4be7f5eb1c2b72f079b4ff8b5fce9d5c"
+checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
 dependencies = [
  "serde",
  "smallvec",
@@ -5161,9 +5154,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -5186,9 +5179,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5196,24 +5189,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5223,9 +5216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5233,22 +5226,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-streams"
@@ -5265,9 +5258,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5315,11 +5308,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5334,7 +5327,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5352,7 +5345,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5372,17 +5365,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -5393,9 +5387,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5405,9 +5399,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5417,9 +5411,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5429,9 +5429,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5441,9 +5441,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5453,9 +5453,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5465,15 +5465,24 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -5499,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
@@ -5511,29 +5520,29 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
@@ -5546,5 +5555,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.68",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,21 +296,24 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum-server"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447f28c85900215cc1bea282f32d4a2f22d55c5a300afdfbc661c8d6a632e063"
+checksum = "c1ad46c3ec4e12f4a4b6835e173ba21c25e484c9d02b49770bf006ce5367c036"
 dependencies = [
  "arc-swap",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.0",
+ "hyper-util",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 2.1.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+ "tower",
  "tower-service",
 ]
 
@@ -833,11 +842,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -940,14 +950,14 @@ dependencies = [
 name = "dpop"
 version = "0.1.1"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "canonical_json",
  "claims",
  "frunk_core",
  "gdp_rs",
  "headers",
- "http",
+ "http 1.1.0",
  "http-serde",
  "http_uri",
  "itertools",
@@ -972,7 +982,7 @@ name = "dyn_problem"
 version = "0.1.1"
 dependencies = [
  "futures",
- "http",
+ "http 1.1.0",
  "http-api-problem",
  "iri-string",
  "once_cell",
@@ -1375,7 +1385,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1423,14 +1452,14 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1438,11 +1467,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -1502,14 +1531,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-api-problem"
-version = "0.57.0"
+name = "http"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce650a2c63171c9d92f95887c8d81154b77385301c8a581b9af96491f52d765"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
- "http",
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-api-problem"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfa6ba9e2d8cf5299faf4721520ff7997989431d2c8fdf702eb8b1a4313b625"
+dependencies = [
+ "http 1.1.0",
  "http-api-problem-derive",
- "hyper",
  "serde",
  "serde_json",
 ]
@@ -1530,19 +1569,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-cache"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bae69908277d47122334bf6009e514cd3d24e65d0bf2b56f1b45db6ad8864d"
+checksum = "d6ffb12b95bb2a369fe47ca8924016c72c2fa0e6059ba98bd1516f558696c5a8"
 dependencies = [
  "async-trait",
  "bincode",
- "http",
+ "http 1.1.0",
  "http-cache-semantics",
  "httpdate",
  "moka",
@@ -1552,47 +1614,40 @@ dependencies = [
 
 [[package]]
 name = "http-cache-reqwest"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5a40915f9da8f3feef6f942f9aace74393803c47bce6870f19cd2b5123f27a"
+checksum = "be3e27c4e2e510571cbcc601407b639667146aa9a4e818d5cc1d97c8b4b27d61"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 1.1.0",
  "http-cache",
  "http-cache-semantics",
- "reqwest",
+ "reqwest 0.12.5",
  "reqwest-middleware",
  "serde",
- "task-local-extensions",
  "url",
 ]
 
 [[package]]
 name = "http-cache-semantics"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aec9f678bca3f4a15194b980f20ed9bfe0dd38e8d298c65c559a93dfbd6380a"
+checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
 dependencies = [
- "http",
+ "http 1.1.0",
  "http-serde",
  "serde",
  "time",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "http-serde"
-version = "1.1.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
- "http",
+ "http 1.1.0",
  "serde",
 ]
 
@@ -1605,7 +1660,7 @@ dependencies = [
  "ecow",
  "either",
  "headers",
- "http",
+ "http 1.1.0",
  "iri-string",
  "itertools",
  "mime",
@@ -1664,9 +1719,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1679,30 +1734,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls",
+ "http 0.2.12",
+ "hyper 0.14.29",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.0",
+ "hyper-util",
+ "rustls 0.23.10",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.4.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.4.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1816,9 +1933,9 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2171,10 +2288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "manas"
-version = "0.1.0"
-
-[[package]]
 name = "manas_access_control"
 version = "0.1.0"
 dependencies = [
@@ -2214,7 +2327,7 @@ dependencies = [
  "futures",
  "gdp_rs",
  "headers",
- "http",
+ "http 1.1.0",
  "http_typed_headers",
  "http_uri",
  "itertools",
@@ -2225,7 +2338,7 @@ dependencies = [
  "picky",
  "rdf_utils",
  "rdf_vocabularies",
- "reqwest",
+ "reqwest 0.12.5",
  "serde",
  "serde_json",
  "solid_oidc_types",
@@ -2242,7 +2355,6 @@ dependencies = [
 name = "manas_http"
 version = "0.1.1"
 dependencies = [
- "anyhow",
  "async-convert",
  "async-once-cell",
  "async-stream",
@@ -2256,18 +2368,22 @@ dependencies = [
  "either",
  "frunk_core",
  "futures",
+ "futures-util",
  "gdp_rs",
  "headers",
- "http",
+ "http 1.1.0",
  "http-api-problem",
+ "http-body 1.0.0",
+ "http-body-util",
  "http_typed_headers",
  "http_uri",
- "hyper",
+ "hyper 1.4.0",
  "if_chain",
  "iri-string",
  "mime",
  "once_cell",
  "percent-encoding",
+ "pin-project-lite",
  "rdf_dynsyn",
  "rdf_utils",
  "regex",
@@ -2275,6 +2391,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sophia_api",
+ "sync_wrapper 1.0.1",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -2292,8 +2409,8 @@ dependencies = [
  "dyn_problem",
  "futures",
  "ghost",
+ "http 1.1.0",
  "http-api-problem",
- "hyper",
  "manas_http",
  "manas_repo",
  "manas_space",
@@ -2322,8 +2439,8 @@ dependencies = [
  "futures",
  "gdp_rs",
  "headers",
- "http",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "if_chain",
  "iri-string",
  "itertools",
@@ -2352,15 +2469,13 @@ dependencies = [
 name = "manas_repo_layers"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-convert",
  "capped_stream",
  "dyn_problem",
  "frunk_core",
  "futures",
  "headers",
- "http",
- "hyper",
+ "http 1.1.0",
  "if_chain",
  "manas_http",
  "manas_repo",
@@ -2404,8 +2519,7 @@ dependencies = [
  "gdp_rs",
  "headers",
  "hex",
- "http-body",
- "hyper",
+ "http-body 1.0.0",
  "if_chain",
  "itertools",
  "manas_access_control",
@@ -2475,9 +2589,9 @@ dependencies = [
  "frunk_core",
  "futures",
  "gdp_rs",
- "http",
+ "http 1.1.0",
  "http-cache-reqwest",
- "hyper",
+ "hyper 1.4.0",
  "manas_access_control",
  "manas_authentication",
  "manas_http",
@@ -2503,7 +2617,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-log 0.1.4",
+ "tracing-log",
  "tracing-subscriber",
  "typed_record",
  "upon",
@@ -2542,7 +2656,7 @@ dependencies = [
  "dyn-clone",
  "gdp_rs",
  "headers",
- "http",
+ "http 1.1.0",
  "if_chain",
  "iri-string",
  "manas_http",
@@ -2560,7 +2674,7 @@ name = "manas_specs"
 version = "0.1.0"
 dependencies = [
  "dyn_problem",
- "http",
+ "http 1.1.0",
  "http-api-problem",
  "iri-string",
  "manas_http",
@@ -2602,9 +2716,9 @@ dependencies = [
  "gdp_rs",
  "ghost",
  "headers",
- "http",
+ "http 1.1.0",
  "http-api-problem",
- "hyper",
+ "http-body 1.0.0",
  "if_chain",
  "iri-string",
  "manas_access_control",
@@ -2898,14 +3012,14 @@ dependencies = [
  "flagset",
  "futures",
  "getrandom",
- "http",
+ "http 0.2.12",
  "log",
  "md-5",
  "once_cell",
  "percent-encoding",
  "quick-xml 0.30.0",
  "reqsign",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "sha2",
@@ -3449,6 +3563,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,7 +3709,7 @@ dependencies = [
  "mime",
  "once_cell",
  "rdf-types",
- "reqwest",
+ "reqwest 0.12.5",
  "reqwest-middleware",
  "resiter",
  "rio_api",
@@ -3687,14 +3848,14 @@ dependencies = [
  "hex",
  "hmac",
  "home",
- "http",
+ "http 0.2.12",
  "jsonwebtoken",
  "log",
  "once_cell",
  "percent-encoding",
  "quick-xml 0.31.0",
  "rand",
- "reqwest",
+ "reqwest 0.11.27",
  "rsa",
  "rust-ini",
  "serde",
@@ -3714,32 +3875,74 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.29",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-native-certs",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.0",
+ "hyper-rustls 0.27.2",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-native-certs",
- "rustls-pemfile",
+ "quinn",
+ "rustls 0.23.10",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -3748,22 +3951,22 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.2.5"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+checksum = "39346a33ddfe6be00cbc17a34ce996818b97b230b87229f10114693becca1268"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
- "reqwest",
+ "http 1.1.0",
+ "reqwest 0.12.5",
  "serde",
- "task-local-extensions",
  "thiserror",
+ "tower-service",
 ]
 
 [[package]]
@@ -3878,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.18.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3890,12 +4093,13 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.18.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
 dependencies = [
  "cfg-if",
  "glob",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -3972,6 +4176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,8 +4211,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.5",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4012,7 +4236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -4027,12 +4251,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -4579,6 +4830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4610,15 +4867,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
 
 [[package]]
 name = "tempfile"
@@ -4767,7 +5015,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.10",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -4858,17 +5117,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
- "futures-core",
  "futures-util",
- "http",
- "http-body",
- "http-range-header",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -4922,17 +5180,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -4957,7 +5204,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4998,7 +5245,7 @@ name = "typed_record"
 version = "0.1.1"
 dependencies = [
  "anymap2",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -5073,9 +5320,9 @@ checksum = "151ac09978d3c2862c4e39b557f4eceee2cc72150bc4cb4f16abf061b6e381fb"
 
 [[package]]
 name = "upon"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a9260fe394dfd8ab204a8eab40f88eb9a331bb852147d24fc0aff6b30daa02"
+checksum = "9fe29601d1624f104fa9a35ea71a5f523dd8bd1cfc8c31f8124ad2b829f013c0"
 dependencies = [
  "serde",
 ]
@@ -5277,7 +5524,7 @@ dependencies = [
  "iri-string",
  "mime",
  "rdf_dynsyn",
- "reqwest",
+ "reqwest 0.12.5",
  "serde",
  "sophia_api",
  "thiserror",
@@ -5286,9 +5533,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -5492,6 +5742,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
     "crates/manas_server/recipes/single_fs_wac",
     "crates/manas_server/recipes/single_fs_noauth",
     "crates/manas_server/recipes/single_s3_wac",
-    "crates/manas"
+    # "crates/manas"
     # "crates/manas_tauri"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ members = [
     "crates/manas_storage",
     "crates/manas_podverse",
     "crates/manas_server",
-    "crates/manas_server/recipes/single_fs_wac",
-    "crates/manas_server/recipes/single_fs_noauth",
-    "crates/manas_server/recipes/single_s3_wac",
+    # "crates/manas_server/recipes/single_fs_wac",
+    # "crates/manas_server/recipes/single_fs_noauth",
+    # "crates/manas_server/recipes/single_s3_wac",
     # "crates/manas"
     # "crates/manas_tauri"
 ]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Along with these main crates, Manas project provides many utility crates that he
 - [`webid`](https://docs.rs/webid): Rust crate for webid.
 - ... etc.
 
+Rust MSRV: 1.79.0
+
 ## Contributors
 
 Thanks to every contributor, who helped in making `manas` possible. A not so exhaustive list in no perticular order:

--- a/crates/manas/Cargo.toml
+++ b/crates/manas/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "A modular framework for implementing solid compatible servers in rust"
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_access_control/Cargo.toml
+++ b/crates/manas_access_control/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_access_control"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate Defines traits for access control systems compatible with solid storage space. Provides default implementations confirming to [`ACP`](https://solid.github.io/authorization-panel/acp-specification/), [`WAC`](https://solid.github.io/web-access-control-spec/) authorization systems."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_access_control/Cargo.toml
+++ b/crates/manas_access_control/Cargo.toml
@@ -23,7 +23,7 @@ manas_authentication = { version = "0.1.0", path = "../manas_authentication", fe
 http_typed_headers = { version = "0.1.0", path = "../../fcrates/http_typed_headers", default-features = false, features = ["wac-allow"] }
 manas_space = { version = "0.1.0", path = "../manas_space" }
 async-recursion = "1.1.1"
-itertools = "0.11.0"
+itertools = "0.13.0"
 paste = "1.0.15"
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils" }
 rdf_vocabularies = { version = "0.2.0", features = ["ns-acp", "ns-acl", "ns-foaf","ns-rdf"] }

--- a/crates/manas_access_control/Cargo.toml
+++ b/crates/manas_access_control/Cargo.toml
@@ -22,23 +22,23 @@ http_uri = { version = "1.0.1", path = "../../fcrates/http_uri", features = [
 manas_authentication = { version = "0.1.0", path = "../manas_authentication", features = ["creds-context"]}
 http_typed_headers = { version = "0.1.0", path = "../../fcrates/http_typed_headers", default-features = false, features = ["wac-allow"] }
 manas_space = { version = "0.1.0", path = "../manas_space" }
-async-recursion = "1.0.5"
+async-recursion = "1.1.1"
 itertools = "0.11.0"
-paste = "1.0.14"
+paste = "1.0.15"
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils" }
 rdf_vocabularies = { version = "0.2.0", features = ["ns-acp", "ns-acl", "ns-foaf","ns-rdf"] }
 sophia_api = "0.8.0"
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 tower = "0.4.13"
 tracing = { version = "0.1.40", features = ["attributes"] }
 unwrap-infallible = "0.1.5"
 once_cell = "1.19.0"
-vec1 = {version = "1.10.1", features = ["serde"]}
+vec1 = {version = "1.12.1", features = ["serde"]}
 
 # feature: layered-repo-impl
 manas_repo = { version = "0.1.0", path = "../manas_repo", optional = true }
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = ["ext-anymap", "ext-http"]}
-serde = { version = "1.0.196", features = ["derive"] }
+serde = { version = "1.0.203", features = ["derive"] }
 
 
 [features]

--- a/crates/manas_authentication/Cargo.toml
+++ b/crates/manas_authentication/Cargo.toml
@@ -13,11 +13,11 @@ http_uri = { version = "1.0.1", path = "../../fcrates/http_uri", features = [
     "serde",
 ] }
 webid = { version = "0.1.0", path = "../../fcrates/webid", features = ["serde"] }
-http = { version = "0.2.11" }
-serde = { version = "1.0.196", features = ["derive"] }
+http = { version = "0.2.12" }
+serde = { version = "1.0.203", features = ["derive"] }
 
 # feature cr-framework
-thiserror = { version = "1.0.56", optional = true }
+thiserror = { version = "1.0.61", optional = true }
 tracing = { version = "0.1.40", optional = true }
 mime = { version = "0.3.17", optional = true }
 http_typed_headers = { version = "0.1.0", path = "../../fcrates/http_typed_headers", default-features = false, features = ["www-authenticate"], optional = true}
@@ -25,14 +25,14 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
     "service",
 ], optional = true }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", optional = true }
-either = { version = "1.9.0", optional = true }
+either = { version = "1.13.0", optional = true }
 itertools = { version = "0.11.0", optional = true }
 headers = { version = "0.3.9", optional = true }
 futures = { version = "0.3.30", optional = true }
 tower = { version = "0.4.13", optional = true }
 
 # feature: solid-oidc
-moka = { version = "0.12.5", optional = true, default-features = false, features = [
+moka = { version = "0.12.7", optional = true, default-features = false, features = [
     "future",
 ] }
 rdf_vocabularies = { version = "0.2.0", features = [
@@ -41,13 +41,13 @@ rdf_vocabularies = { version = "0.2.0", features = [
 ], optional = true }
 sophia_api = { version = "0.8.0", optional = true }
 unwrap-infallible = "0.1.5"
-reqwest = { version = "0.11.24", features = ["json"], optional = true, default-features = false}
+reqwest = { version = "0.11.27", features = ["json"], optional = true, default-features = false}
 picky = { version = "7.0.0-rc.8", optional = true, default-features = false }
 dpop = { version = "0.1.1", path = "../../fcrates/dpop", optional = true, features = [
     "http-header",
 ] }
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs", features = ["serde"] }
-serde_json = { version = "1.0.113", optional = true }
+serde_json = { version = "1.0.120", optional = true }
 solid_oidc_types = { version = "0.1.0", path = "../../fcrates/solid_oidc_types", optional = true }
 once_cell = { version = "1.19.0", optional = true }
 unicase = "2.7.0"

--- a/crates/manas_authentication/Cargo.toml
+++ b/crates/manas_authentication/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_authentication"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides implementations of various http authentication schemes for solid storage resource servers and authorization servers."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_authentication/Cargo.toml
+++ b/crates/manas_authentication/Cargo.toml
@@ -13,7 +13,7 @@ http_uri = { version = "1.0.1", path = "../../fcrates/http_uri", features = [
     "serde",
 ] }
 webid = { version = "0.1.0", path = "../../fcrates/webid", features = ["serde"] }
-http = { version = "0.2.12" }
+http = { version = "1.1.0" }
 serde = { version = "1.0.203", features = ["derive"] }
 
 # feature cr-framework
@@ -26,8 +26,8 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
 ], optional = true }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", optional = true }
 either = { version = "1.13.0", optional = true }
-itertools = { version = "0.11.0", optional = true }
-headers = { version = "0.3.9", optional = true }
+itertools = { version = "0.13.0", optional = true }
+headers = { version = "0.4.0", optional = true }
 futures = { version = "0.3.30", optional = true }
 tower = { version = "0.4.13", optional = true }
 
@@ -41,7 +41,7 @@ rdf_vocabularies = { version = "0.2.0", features = [
 ], optional = true }
 sophia_api = { version = "0.8.0", optional = true }
 unwrap-infallible = "0.1.5"
-reqwest = { version = "0.11.27", features = ["json"], optional = true, default-features = false}
+reqwest = { version = "0.12.5", features = ["json"], optional = true, default-features = false}
 picky = { version = "7.0.0-rc.8", optional = true, default-features = false }
 dpop = { version = "0.1.1", path = "../../fcrates/dpop", optional = true, features = [
     "http-header",

--- a/crates/manas_http/Cargo.toml
+++ b/crates/manas_http/Cargo.toml
@@ -20,9 +20,9 @@ tracing = { version = "0.1.40", features = ["attributes"] }
 ecow = "0.2.2"
 
 # feature: typed-headers
-http_typed_headers = { version = "0.1.0", path = "../../fcrates/http_typed_headers", optional = true}
-headers = { version = "0.3.9", optional = true }
-http = { version = "0.2.12", optional = true }
+http_typed_headers = { version = "0.1.0", path = "../../fcrates/http_typed_headers", optional = true }
+headers = { version = "0.4.0", optional = true }
+http = { version = "1.1.0", optional = true }
 smallvec = { version = "1.13.2", optional = true }
 chrono = { version = "0.4.38", optional = true, default-features = false, features = [
     "std",
@@ -35,16 +35,23 @@ serde = { version = "1.0.203", features = ["derive"], optional = true }
 # feature: representation
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
     "ext-anymap",
-], optional = true}
-hyper = { version = "0.14.29", features = ["stream"], optional = true }
+], optional = true }
 mime = { version = "0.3.17", optional = true }
 either = { version = "1.13.0", optional = true }
+
+# feature: body
+http-body-util = { version = "0.1.2", optional = true }
+http-body = { version = "1.0.0", optional = true }
+futures-util = { version = "0.3.30", optional = true }
+pin-project-lite = { version = "0.2.14", optional = true }
+sync_wrapper = { version = "1.0.1", optional = true }
 
 # feature: impl-representation
 bytes = { version = "1.6.0", optional = true }
 futures = { version = "0.3.30", optional = true }
-anyhow = { version = "1.0.86", optional = true }
-rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils", optional = true, features = ["compat-ecow"]}
+rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils", optional = true, features = [
+    "compat-ecow",
+] }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", optional = true }
 async-stream = { version = "0.3.5", optional = true }
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", optional = true, features = [
@@ -59,31 +66,77 @@ capped_stream = { version = "0.1.1", path = "../../fcrates/capped_stream", optio
 # feature: service
 tower = { version = "0.4.13", optional = true, features = ["util"] }
 dyn-clone = { version = "1.0.17", optional = true }
-http-api-problem = { version = "0.57.0", features = [
+http-api-problem = { version = "0.58.0", features = [
     "api-error",
-    "hyper",
 ], optional = true }
 
 # feature: conditional-req
 if_chain = { version = "1.0.2", optional = true }
 
+# feature: hyper
+hyper = { version = "1.0", optional = true }
+
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }
-rstest = { version = "0.18.2", optional = true }
+rstest = { version = "0.21.0", optional = true }
 
 [features]
 serde = ["dep:serde", "iri-string/serde"]
-typed-headers = ["dep:http_typed_headers", "dep:chrono", "dep:smallvec", "dep:http", "dep:headers"]
-representation = ["typed-headers", "dep:typed_record", "dep:hyper", "dep:mime"]
-impl-representation = ["representation", "dep:either", "dep:bytes", "dep:futures", "dep:anyhow", "dep:rdf_utils", "dep:dyn_problem", "dep:async-stream", "dep:rdf_dynsyn", "dep:if_chain", "dep:tokio", "dep:tokio-util", "dep:tower", "dep:dyn-clone", "http_uri/sophia", "dep:sophia_api", "dep:async-once-cell", "dep:capped_stream"]
-service = ["dep:tower", "dep:futures", "dep:dyn-clone", "dep:http", "dep:hyper", "dep:http-api-problem", "typed-headers"]
+typed-headers = [
+    "dep:http_typed_headers",
+    "dep:chrono",
+    "dep:smallvec",
+    "dep:http",
+    "dep:headers",
+]
+body = [
+    "dep:http-body",
+    "dep:http-body-util",
+    "dep:futures-util",
+    "dep:sync_wrapper",
+    "dep:pin-project-lite",
+]
+representation = ["typed-headers", "dep:typed_record", "dep:mime"]
+impl-representation = [
+    "representation",
+    "body",
+    "dep:either",
+    "dep:bytes",
+    "dep:futures",
+    # "dep:anyhow",
+    "dep:rdf_utils",
+    "dep:dyn_problem",
+    "dep:async-stream",
+    "dep:rdf_dynsyn",
+    "dep:if_chain",
+    "dep:tokio",
+    "dep:tokio-util",
+    "dep:tower",
+    "dep:dyn-clone",
+    "http_uri/sophia",
+    "dep:sophia_api",
+    "dep:async-once-cell",
+    "dep:capped_stream",
+]
+problem = ["body", "dep:http-api-problem", "dep:http"]
+service = [
+    "problem",
+    "dep:tower",
+    "dep:futures",
+    "dep:dyn-clone",
+    "dep:http",
+    "dep:http-api-problem",
+    "typed-headers",
+    "body",
+]
 conditional_req = ["dep:if_chain", "dep:headers", "dep:http"]
 test-utils = ["dep:rstest", "dep:claims"]
+hyper = ["body", "dep:hyper"]
 
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/manas_http/Cargo.toml
+++ b/crates/manas_http/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_http"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides extended functionality for handling http semantics, that integrates into [`hyper`](https://docs.rs/hyper/latest/hyper/index.html) ecosystem."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_http/Cargo.toml
+++ b/crates/manas_http/Cargo.toml
@@ -9,56 +9,56 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 http_uri = { version = "1.0.1", path = "../../fcrates/http_uri" }
 frunk_core = "0.4.2"
-iri-string = { version = "0.7.0", features = ["serde"] }
+iri-string = { version = "0.7.2", features = ["serde"] }
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
 once_cell = "1.19.0"
 percent-encoding = "2.3.1"
-regex = "1.10.3"
+regex = "1.10.5"
 uriparse = "0.6.4"
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 tracing = { version = "0.1.40", features = ["attributes"] }
-ecow = "0.2.0"
+ecow = "0.2.2"
 
 # feature: typed-headers
 http_typed_headers = { version = "0.1.0", path = "../../fcrates/http_typed_headers", optional = true}
 headers = { version = "0.3.9", optional = true }
-http = { version = "0.2.11", optional = true }
-smallvec = { version = "1.13.1", optional = true }
-chrono = { version = "0.4.33", optional = true, default-features = false, features = [
+http = { version = "0.2.12", optional = true }
+smallvec = { version = "1.13.2", optional = true }
+chrono = { version = "0.4.38", optional = true, default-features = false, features = [
     "std",
 ] }
 async-convert = "1.0.0"
 
 # feature: serde
-serde = { version = "1.0.196", features = ["derive"], optional = true }
+serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 # feature: representation
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
     "ext-anymap",
 ], optional = true}
-hyper = { version = "0.14.28", features = ["stream"], optional = true }
+hyper = { version = "0.14.29", features = ["stream"], optional = true }
 mime = { version = "0.3.17", optional = true }
-either = { version = "1.9.0", optional = true }
+either = { version = "1.13.0", optional = true }
 
 # feature: impl-representation
-bytes = { version = "1.5.0", optional = true }
+bytes = { version = "1.6.0", optional = true }
 futures = { version = "0.3.30", optional = true }
-anyhow = { version = "1.0.79", optional = true }
+anyhow = { version = "1.0.86", optional = true }
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils", optional = true, features = ["compat-ecow"]}
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", optional = true }
 async-stream = { version = "0.3.5", optional = true }
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", optional = true, features = [
     "async",
 ] }
-tokio = { version = "1.36.0", features = ["rt", "io-util"], optional = true }
-tokio-util = { version = "0.7.10", optional = true, features = ["io-util"] }
+tokio = { version = "1.38.0", features = ["rt", "io-util"], optional = true }
+tokio-util = { version = "0.7.11", optional = true, features = ["io-util"] }
 sophia_api = { version = "0.8.0", optional = true }
 async-once-cell = { version = "0.5.3", optional = true }
 capped_stream = { version = "0.1.1", path = "../../fcrates/capped_stream", optional = true }
 
 # feature: service
 tower = { version = "0.4.13", optional = true, features = ["util"] }
-dyn-clone = { version = "1.0.16", optional = true }
+dyn-clone = { version = "1.0.17", optional = true }
 http-api-problem = { version = "0.57.0", features = [
     "api-error",
     "hyper",

--- a/crates/manas_http/src/body/mod.rs
+++ b/crates/manas_http/src/body/mod.rs
@@ -1,0 +1,221 @@
+//! I provide utilities for http body handling..
+//!
+
+// NOTE: Copied from https://docs.rs/axum-core/0.4.3/src/axum_core/body.rs.html
+// as axum people already shimmed for previous Body funtionality.
+
+use crate::BoxError;
+use bytes::Bytes;
+use futures_util::stream::Stream;
+use futures_util::TryStream;
+use http_body::{Body as _, Frame};
+use http_body_util::BodyExt;
+use pin_project_lite::pin_project;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use sync_wrapper::SyncWrapper;
+
+type BoxBody = http_body_util::combinators::UnsyncBoxBody<Bytes, BoxError>;
+
+fn boxed<B>(body: B) -> BoxBody
+where
+    B: http_body::Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    try_downcast(body).unwrap_or_else(|body| body.map_err(Into::into).boxed_unsync())
+}
+
+pub(crate) fn try_downcast<T, K>(k: K) -> Result<T, K>
+where
+    T: 'static,
+    K: Send + 'static,
+{
+    let mut k = Some(k);
+    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
+        Ok(k.take().unwrap())
+    } else {
+        Err(k.unwrap())
+    }
+}
+
+/// The body type used in axum requests and responses.
+#[derive(Debug)]
+pub struct Body(BoxBody);
+
+impl Body {
+    /// Create a new `Body` that wraps another [`http_body::Body`].
+    pub fn new<B>(body: B) -> Self
+    where
+        B: http_body::Body<Data = Bytes> + Send + 'static,
+        B::Error: Into<BoxError>,
+    {
+        try_downcast(body).unwrap_or_else(|body| Self(boxed(body)))
+    }
+
+    /// Create an empty body.
+    pub fn empty() -> Self {
+        Self::new(http_body_util::Empty::new())
+    }
+
+    /// Create a new `Body` from a [`Stream`].
+    ///
+    /// [`Stream`]: https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html
+    pub fn from_stream<S>(stream: S) -> Self
+    where
+        S: TryStream + Send + 'static,
+        S::Ok: Into<Bytes>,
+        S::Error: Into<BoxError>,
+    {
+        Self::new(StreamBody {
+            stream: SyncWrapper::new(stream),
+        })
+    }
+
+    /// Convert the body into a [`Stream`] of data frames.
+    ///
+    /// Non-data frames (such as trailers) will be discarded. Use [`http_body_util::BodyStream`] if
+    /// you need a [`Stream`] of all frame types.
+    ///
+    /// [`http_body_util::BodyStream`]: https://docs.rs/http-body-util/latest/http_body_util/struct.BodyStream.html
+    pub fn into_data_stream(self) -> BodyDataStream {
+        BodyDataStream { inner: self }
+    }
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl From<()> for Body {
+    fn from(_: ()) -> Self {
+        Self::empty()
+    }
+}
+
+macro_rules! body_from_impl {
+    ($ty:ty) => {
+        impl From<$ty> for Body {
+            fn from(buf: $ty) -> Self {
+                Self::new(http_body_util::Full::from(buf))
+            }
+        }
+    };
+}
+
+body_from_impl!(&'static [u8]);
+body_from_impl!(std::borrow::Cow<'static, [u8]>);
+body_from_impl!(Vec<u8>);
+
+body_from_impl!(&'static str);
+body_from_impl!(std::borrow::Cow<'static, str>);
+body_from_impl!(String);
+
+body_from_impl!(Bytes);
+
+impl http_body::Body for Body {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    #[inline]
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.0).poll_frame(cx)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.0.size_hint()
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.0.is_end_stream()
+    }
+}
+
+/// A stream of data frames.
+///
+/// Created with [`Body::into_data_stream`].
+#[derive(Debug)]
+pub struct BodyDataStream {
+    inner: Body,
+}
+
+impl Stream for BodyDataStream {
+    type Item = Result<Bytes, BoxError>;
+
+    #[inline]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match futures_util::ready!(Pin::new(&mut self.inner).poll_frame(cx)?) {
+                Some(frame) => match frame.into_data() {
+                    Ok(data) => return Poll::Ready(Some(Ok(data))),
+                    Err(_frame) => {}
+                },
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+impl http_body::Body for BodyDataStream {
+    type Data = Bytes;
+    type Error = BoxError;
+
+    #[inline]
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.inner).poll_frame(cx)
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+pin_project! {
+    struct StreamBody<S> {
+        #[pin]
+        stream: SyncWrapper<S>,
+    }
+}
+
+impl<S> http_body::Body for StreamBody<S>
+where
+    S: TryStream,
+    S::Ok: Into<Bytes>,
+    S::Error: Into<BoxError>,
+{
+    type Data = Bytes;
+    type Error = BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let stream = self.project().stream.get_pin_mut();
+        match futures_util::ready!(stream.try_poll_next(cx)) {
+            Some(Ok(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk.into())))),
+            Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+#[test]
+fn test_try_downcast() {
+    assert_eq!(try_downcast::<i32, _>(5_u32), Err(5_u32));
+    assert_eq!(try_downcast::<i32, _>(5_i32), Ok(5_i32));
+}

--- a/crates/manas_http/src/lib.rs
+++ b/crates/manas_http/src/lib.rs
@@ -13,8 +13,14 @@ pub mod header;
 #[cfg(feature = "conditional_req")]
 pub mod conditional_req;
 
+#[cfg(feature = "body")]
+pub mod body;
+
 #[cfg(feature = "representation")]
 pub mod representation;
+
+#[cfg(feature = "problem")]
+pub mod problem;
 
 #[cfg(feature = "service")]
 pub mod service;
@@ -23,3 +29,6 @@ pub mod uri;
 
 #[cfg(feature = "typed-headers")]
 pub use http_typed_headers::define_static_rel_types;
+
+/// Alias for a type-erased error type.
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;

--- a/crates/manas_http/src/problem/mod.rs
+++ b/crates/manas_http/src/problem/mod.rs
@@ -1,0 +1,64 @@
+//! I provide utilities to deal with http problems.
+//!
+
+use http::{
+    header::{CONTENT_LENGTH, CONTENT_TYPE},
+    HeaderValue, Response, StatusCode,
+};
+use http_api_problem::{ApiError, HttpApiProblem, PROBLEM_JSON_MEDIA_TYPE};
+use seal::Sealed;
+
+use crate::body::Body;
+
+mod seal {
+    use http_api_problem::{ApiError, HttpApiProblem};
+
+    pub trait Sealed {}
+    impl Sealed for HttpApiProblem {}
+    impl Sealed for ApiError {}
+}
+
+/// An extension trait for [`HttpApiProblem`].
+pub trait HttpApiProblemExt: Sealed {
+    /// Convert problem to http response.
+    fn to_http_response(&self) -> Response<Body>;
+}
+
+impl HttpApiProblemExt for HttpApiProblem {
+    fn to_http_response(&self) -> Response<Body> {
+        let json = self.json_bytes();
+        let length = json.len() as u64;
+
+        let (mut parts, body) = Response::new(json.into()).into_parts();
+
+        parts.headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static(PROBLEM_JSON_MEDIA_TYPE),
+        );
+        parts.headers.insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&length.to_string()).unwrap(),
+        );
+        parts.status = self
+            .status
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+            .as_u16()
+            .try_into()
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        Response::from_parts(parts, body)
+    }
+}
+
+/// An extension trait for [`ApiError`].
+pub trait ApiErrorExt {
+    /// Convert error into http response.
+    fn into_http_response(self) -> Response<Body>;
+}
+
+impl ApiErrorExt for ApiError {
+    fn into_http_response(self) -> Response<Body> {
+        let problem = self.into_http_api_problem();
+        problem.to_http_response()
+    }
+}

--- a/crates/manas_http/src/representation/impl_/basic/mod.rs
+++ b/crates/manas_http/src/representation/impl_/basic/mod.rs
@@ -138,7 +138,7 @@ impl From<BasicRepresentation<EcoQuadsInmem>> for BasicRepresentation<QuadsData>
 
 #[async_trait]
 impl async_convert::TryFrom<BasicRepresentation<BytesData>> for BasicRepresentation<BytesInmem> {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(rep: BasicRepresentation<BytesData>) -> Result<Self, Self::Error> {
         match rep.into_either() {
@@ -150,7 +150,7 @@ impl async_convert::TryFrom<BasicRepresentation<BytesData>> for BasicRepresentat
 
 #[async_trait]
 impl async_convert::TryFrom<BasicRepresentation<BytesStream>> for BasicRepresentation<BytesInmem> {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(rep: BasicRepresentation<BytesStream>) -> Result<Self, Self::Error> {
         Ok(BasicRepresentation {

--- a/crates/manas_http/src/representation/impl_/binary/mod.rs
+++ b/crates/manas_http/src/representation/impl_/binary/mod.rs
@@ -96,7 +96,7 @@ impl<BD> BinaryRepresentation<BD> {
 impl async_convert::TryFrom<BinaryRepresentation<BytesStream>>
     for BinaryRepresentation<BytesInmem>
 {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(rep: BinaryRepresentation<BytesStream>) -> Result<Self, Self::Error> {
         Ok(BinaryRepresentation {
@@ -108,7 +108,7 @@ impl async_convert::TryFrom<BinaryRepresentation<BytesStream>>
 
 #[async_trait]
 impl async_convert::TryFrom<BinaryRepresentation> for BinaryRepresentation<BytesInmem> {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(rep: BinaryRepresentation) -> Result<Self, Self::Error> {
         match rep.into_either() {

--- a/crates/manas_http/src/representation/impl_/common/data/bytes.rs
+++ b/crates/manas_http/src/representation/impl_/common/data/bytes.rs
@@ -2,7 +2,9 @@
 //!
 
 use async_convert::async_trait;
-use hyper::body::SizeHint;
+use http_body::SizeHint;
+
+use crate::{body::Body, BoxError};
 
 use super::{bytes_inmem::BytesInmem, bytes_stream::BytesStream};
 
@@ -23,9 +25,9 @@ impl Default for BytesData {
     }
 }
 
-impl From<hyper::Body> for BytesData {
+impl From<Body> for BytesData {
     #[inline]
-    fn from(value: hyper::Body) -> Self {
+    fn from(value: Body) -> Self {
         Self::Stream(value.into())
     }
 }
@@ -65,7 +67,7 @@ impl BytesData {
 
 #[async_trait]
 impl async_convert::TryFrom<BytesData> for BytesInmem {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(data: BytesData) -> Result<Self, Self::Error> {
         match data {

--- a/crates/manas_http/src/representation/impl_/common/data/quads.rs
+++ b/crates/manas_http/src/representation/impl_/common/data/quads.rs
@@ -1,8 +1,9 @@
 //! I define type to represent quads data that can be streaming/in-memory..
 //!
 
+use crate::BoxError;
 use async_convert::async_trait;
-use hyper::body::SizeHint;
+use http_body::SizeHint;
 
 use super::{quads_inmem::EcoQuadsInmem, quads_stream::QuadsStream};
 
@@ -51,7 +52,7 @@ impl QuadsData {
 
 #[async_trait]
 impl async_convert::TryFrom<QuadsData> for EcoQuadsInmem {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(data: QuadsData) -> Result<Self, Self::Error> {
         match data {

--- a/crates/manas_http/src/representation/impl_/common/data/quads_stream.rs
+++ b/crates/manas_http/src/representation/impl_/common/data/quads_stream.rs
@@ -4,13 +4,15 @@
 use async_convert::async_trait;
 use ecow::EcoVec;
 use futures::{stream::BoxStream, TryStreamExt};
-use hyper::body::SizeHint;
+use http_body::SizeHint;
 use rdf_utils::model::{dataset::CompatDataset, quad::ArcQuad};
+
+use crate::BoxError;
 
 use super::quads_inmem::{EcoQuadsInmem, QuadsInmem};
 
 /// Type alias for a boxed fallible quads stream.
-pub type BoxQuadsStream = BoxStream<'static, Result<ArcQuad, anyhow::Error>>;
+pub type BoxQuadsStream = BoxStream<'static, Result<ArcQuad, BoxError>>;
 
 /// Quads stream data.
 pub struct QuadsStream {
@@ -42,7 +44,7 @@ impl From<EcoQuadsInmem> for QuadsStream {
 
 #[async_trait]
 impl async_convert::TryFrom<QuadsStream> for EcoQuadsInmem {
-    type Error = anyhow::Error;
+    type Error = BoxError;
 
     async fn try_from(data: QuadsStream) -> Result<Self, Self::Error> {
         Ok(QuadsInmem::new(CompatDataset(

--- a/crates/manas_http/src/service/adapter.rs
+++ b/crates/manas_http/src/service/adapter.rs
@@ -1,0 +1,73 @@
+//! I provide few adapters to use in hyper ecosystem.
+//!
+
+use std::{
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use http::{Request, Response};
+use hyper::body::Incoming;
+use tower::Service;
+
+use crate::body::Body;
+
+/// A middleware [`Service`] that adapts the request body..
+///
+#[derive(Debug)]
+pub struct AdaptIncomingBody<S, ResBody>
+where
+    S: Clone,
+{
+    inner: S,
+    _phantom: PhantomData<fn() -> ResBody>,
+}
+
+impl<S: Clone, ResBody> Clone for AdaptIncomingBody<S, ResBody>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _phantom: self._phantom,
+        }
+    }
+}
+
+impl<S, ResBody> AdaptIncomingBody<S, ResBody>
+where
+    S: Clone,
+{
+    /// Create a new [`AdaptReqBody`].
+    #[inline]
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, ResBody> Service<Request<Incoming>> for AdaptIncomingBody<S, ResBody>
+where
+    S: Service<Request<Body>, Response = Response<ResBody>> + Clone,
+{
+    type Response = Response<ResBody>;
+
+    type Error = S::Error;
+
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, req: Request<Incoming>) -> Self::Future {
+        let (parts, body) = req.into_parts();
+        let req_adapted = Request::from_parts(parts, Body::new(body));
+        self.inner.call(req_adapted)
+    }
+}

--- a/crates/manas_http/src/service/impl_/normal_validate_target_uri.rs
+++ b/crates/manas_http/src/service/impl_/normal_validate_target_uri.rs
@@ -6,10 +6,10 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::body::Body;
 use futures::future::{self, Either, Ready};
 use gdp_rs::{inference_rule::IdentityTransform, predicate::impl_::all_of::IntoPL};
 use http::{header::LOCATION, Request, Response, StatusCode};
-use hyper::Body;
 use tower::Service;
 
 use crate::uri::{

--- a/crates/manas_http/src/service/impl_/reconstruct_target_uri.rs
+++ b/crates/manas_http/src/service/impl_/reconstruct_target_uri.rs
@@ -11,15 +11,16 @@ use futures::future::{self, Either, Ready};
 use headers::{Header, HeaderMapExt, Host};
 use http::{uri::Scheme, HeaderName, Request, Response, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
 use iri_string::types::{UriAbsoluteStr, UriAbsoluteString, UriStr};
 use tower::Service;
 use tracing::{debug, error, info};
 
 use crate::{
+    body::Body,
     header::{
         forwarded::Forwarded, x_forwarded_host::XForwardedHost, x_forwarded_proto::XForwardedProto,
     },
+    problem::ApiErrorExt,
     uri::invariant::AbsoluteHttpUri,
 };
 
@@ -176,7 +177,7 @@ where
             )
             .message("Invalid request target")
             .finish()
-            .into_hyper_response())))
+            .into_http_response())))
         }
     }
 }

--- a/crates/manas_http/src/service/impl_/route_by_method.rs
+++ b/crates/manas_http/src/service/impl_/route_by_method.rs
@@ -10,10 +10,12 @@ use std::{
 
 use dyn_clone::clone_box;
 use http::{Method, Request, Response, StatusCode};
-use hyper::Body;
 use tower::{Service, ServiceExt};
 
-use crate::service::{BoxHttpResponseFuture, HttpService};
+use crate::{
+    body::Body,
+    service::{BoxHttpResponseFuture, HttpService},
+};
 
 /// A [`Service`] that routes http requests to registered
 /// service corresponding to request method.

--- a/crates/manas_http/src/service/mod.rs
+++ b/crates/manas_http/src/service/mod.rs
@@ -8,6 +8,9 @@ use futures::future::BoxFuture;
 use http::{Request, Response};
 use tower::Service;
 
+#[cfg(feature = "hyper")]
+pub mod adapter;
+
 pub mod impl_;
 pub mod namespaced;
 

--- a/crates/manas_podverse/Cargo.toml
+++ b/crates/manas_podverse/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_podverse"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides traits and implementations for defining, serving, provisioning solid pods and podsets."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_podverse/Cargo.toml
+++ b/crates/manas_podverse/Cargo.toml
@@ -11,7 +11,7 @@ dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features 
 futures = "0.3.30"
 ghost = "0.1.17"
 http-api-problem = { version = "0.57.0", features = ["api-error", "hyper"] }
-hyper = "0.14.28"
+hyper = "0.14.29"
 manas_http = { version = "0.1.1", path = "../manas_http", features = [
     "service",
 ] }
@@ -23,14 +23,14 @@ rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = 
 ] }
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils" }
 rdf_vocabularies = { version = "0.2.0", features = ["ns-rdf", "ns-pim"] }
-regex = "1.10.3"
+regex = "1.10.5"
 sophia_api = "0.8.0"
 tower = "0.4.13"
 tracing = { version = "0.1.40", features = ["attributes"] }
 
 # feature: impl-podset-templated
 dashmap = { version = "5.5.3", optional = true }
-moka = { version = "0.12.5", features = ["future"], optional = true }
+moka = { version = "0.12.7", features = ["future"], optional = true }
 
 
 [features]

--- a/crates/manas_podverse/Cargo.toml
+++ b/crates/manas_podverse/Cargo.toml
@@ -10,8 +10,7 @@ license = "MIT OR Apache-2.0"
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"] }
 futures = "0.3.30"
 ghost = "0.1.17"
-http-api-problem = { version = "0.57.0", features = ["api-error", "hyper"] }
-hyper = "0.14.29"
+http-api-problem = { version = "0.58.0", features = ["api-error"] }
 manas_http = { version = "0.1.1", path = "../manas_http", features = [
     "service",
 ] }
@@ -29,8 +28,9 @@ tower = "0.4.13"
 tracing = { version = "0.1.40", features = ["attributes"] }
 
 # feature: impl-podset-templated
-dashmap = { version = "5.5.3", optional = true }
+dashmap = { version = "6.0.1", optional = true }
 moka = { version = "0.12.7", features = ["future"], optional = true }
+http = "1.1.0"
 
 
 [features]

--- a/crates/manas_podverse/src/pod/service/impl_/basic.rs
+++ b/crates/manas_podverse/src/pod/service/impl_/basic.rs
@@ -5,10 +5,14 @@ use std::{convert::Infallible, marker::PhantomData, sync::Arc, task::Poll};
 
 use dyn_problem::Problem;
 use futures::future::BoxFuture;
-use hyper::{service::Service, Body, Request, Response};
-use manas_http::service::{namespaced::NamespacedHttpService, BoxHttpResponseFuture};
+use http::{Request, Response};
+use manas_http::{
+    body::Body,
+    service::{namespaced::NamespacedHttpService, BoxHttpResponseFuture},
+};
 use manas_space::resource::uri::SolidResourceUri;
 use manas_storage::service::{SolidStorageService, SolidStorageServiceFactory};
+use tower::Service;
 
 use crate::pod::{
     service::{PodService, PodServiceFactory},

--- a/crates/manas_podverse/src/pod/service/impl_/overriden.rs
+++ b/crates/manas_podverse/src/pod/service/impl_/overriden.rs
@@ -5,9 +5,12 @@
 use std::{convert::Infallible, sync::Arc};
 
 use dyn_problem::{ProbFuture, Problem};
-use hyper::{Body, Request, Response};
-use manas_http::service::{
-    impl_::OverridingHttpService, namespaced::NamespacedHttpService, BoxHttpResponseFuture,
+use http::{Request, Response};
+use manas_http::{
+    body::Body,
+    service::{
+        impl_::OverridingHttpService, namespaced::NamespacedHttpService, BoxHttpResponseFuture,
+    },
 };
 use manas_space::resource::uri::SolidResourceUri;
 use tower::Service;

--- a/crates/manas_podverse/src/pod/service/impl_/storage_describing.rs
+++ b/crates/manas_podverse/src/pod/service/impl_/storage_describing.rs
@@ -7,9 +7,13 @@ use std::{convert::Infallible, ops::Deref, sync::Arc, task::Poll};
 
 use dyn_problem::Problem;
 use futures::{future::BoxFuture, TryFutureExt};
+use http::{Method, Request, Response, StatusCode};
 use http_api_problem::ApiError;
-use hyper::{service::Service, Body, Method, Request, Response, StatusCode};
-use manas_http::service::{namespaced::NamespacedHttpService, BoxHttpResponseFuture};
+use manas_http::{
+    body::Body,
+    problem::ApiErrorExt,
+    service::{namespaced::NamespacedHttpService, BoxHttpResponseFuture},
+};
 use manas_space::{resource::uri::SolidResourceUri, SolidStorageSpace};
 use manas_storage::SolidStorageExt;
 use rdf_dynsyn::{
@@ -22,7 +26,7 @@ use sophia_api::{
     serializer::{Stringifier, TripleSerializer},
     term::Term,
 };
-use tower::ServiceExt;
+use tower::{Service, ServiceExt};
 use tracing::{error, info};
 
 use crate::pod::{
@@ -76,7 +80,7 @@ where
                     return Ok(ApiError::builder(StatusCode::METHOD_NOT_ALLOWED)
                         .message("Storage description resource is currently immutable.")
                         .finish()
-                        .into_hyper_response());
+                        .into_http_response());
                 }
 
                 // Otherwise create description response.

--- a/crates/manas_podverse/src/pod/service/mod.rs
+++ b/crates/manas_podverse/src/pod/service/mod.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use dyn_problem::{ProbFuture, Problem};
-use hyper::Body;
+use manas_http::body::Body;
 use manas_http::service::namespaced::NamespacedHttpService;
 use tower::Service;
 

--- a/crates/manas_podverse/src/podset/service/impl_/basic.rs
+++ b/crates/manas_podverse/src/podset/service/impl_/basic.rs
@@ -4,8 +4,11 @@
 
 use std::{convert::Infallible, sync::Arc, task::Poll};
 
-use hyper::{Body, Request, Response, StatusCode};
-use manas_http::service::{namespaced::NamespacedHttpService, BoxHttpResponseFuture};
+use http::{Request, Response, StatusCode};
+use manas_http::{
+    body::Body,
+    service::{namespaced::NamespacedHttpService, BoxHttpResponseFuture},
+};
 use manas_space::resource::uri::SolidResourceUri;
 use tower::{Service, ServiceExt};
 use tracing::{error, info, instrument};

--- a/crates/manas_podverse/src/podset/service/impl_/overriden.rs
+++ b/crates/manas_podverse/src/podset/service/impl_/overriden.rs
@@ -4,9 +4,12 @@
 
 use std::{convert::Infallible, sync::Arc};
 
-use hyper::{Body, Request, Response};
-use manas_http::service::{
-    impl_::OverridingHttpService, namespaced::NamespacedHttpService, BoxHttpResponseFuture,
+use http::{Request, Response};
+use manas_http::{
+    body::Body,
+    service::{
+        impl_::OverridingHttpService, namespaced::NamespacedHttpService, BoxHttpResponseFuture,
+    },
 };
 use manas_space::resource::uri::SolidResourceUri;
 use tower::Service;

--- a/crates/manas_podverse/src/podset/service/mod.rs
+++ b/crates/manas_podverse/src/podset/service/mod.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use hyper::Body;
+use manas_http::body::Body;
 use manas_http::service::namespaced::NamespacedHttpService;
 
 use super::PodSet;

--- a/crates/manas_repo/Cargo.toml
+++ b/crates/manas_repo/Cargo.toml
@@ -16,7 +16,6 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
 manas_space = { version = "0.1.0", path = "../manas_space" }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"]}
 futures = "0.3.30"
-hyper = "0.14.29"
 tower = {version = "0.4.13", features=["util"]}
 dyn-clone = "1.0.17"
 if_chain = "1.0.2"
@@ -26,8 +25,8 @@ vec1 = "1.12.1"
 iri-string = "0.7.2"
 thiserror = "1.0.61"
 once_cell = "1.19.0"
-headers = "0.3.9"
-http = "0.2.12"
+headers = "0.4.0"
+http = "1.1.0"
 mime = "0.3.17"
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = [
     "async",
@@ -46,20 +45,21 @@ typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", feature
     "ext-http",
 ] }
 unwrap-infallible = "0.1.5"
-itertools = "0.11.0"
+itertools = "0.13.0"
 sophia_api = "0.8.0"
 manas_authentication = { version = "0.1.0", path = "../manas_authentication" }
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }
-rstest = { version = "0.18.2", optional = true }
+rstest = { version = "0.21.0", optional = true }
+http-body = "1.0.0"
 
 [features]
 test-utils = ["dep:rstest", "dep:claims", "manas_space/test-utils"]
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/manas_repo/Cargo.toml
+++ b/crates/manas_repo/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_repo"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate defines definition traits for manas storage repositories and their services."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_repo/Cargo.toml
+++ b/crates/manas_repo/Cargo.toml
@@ -16,31 +16,31 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
 manas_space = { version = "0.1.0", path = "../manas_space" }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"]}
 futures = "0.3.30"
-hyper = "0.14.28"
+hyper = "0.14.29"
 tower = {version = "0.4.13", features=["util"]}
-dyn-clone = "1.0.16"
+dyn-clone = "1.0.17"
 if_chain = "1.0.2"
-smallvec = "1.13.1"
+smallvec = "1.13.2"
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
-vec1 = "1.10.1"
-iri-string = "0.7.0"
-thiserror = "1.0.56"
+vec1 = "1.12.1"
+iri-string = "0.7.2"
+thiserror = "1.0.61"
 once_cell = "1.19.0"
 headers = "0.3.9"
-http = "0.2.11"
+http = "0.2.12"
 mime = "0.3.17"
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = [
     "async",
 ] }
 tracing = { version = "0.1.40", features = ["attributes"] }
-bytes = "1.5.0"
-async-compat = "0.2.3"
-either = "1.9.0"
+bytes = "1.6.0"
+async-compat = "0.2.4"
+either = "1.13.0"
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils"}
-anyhow = "1.0.79"
-regex = "1.10.3"
-tokio = { version = "1.36.0", features = ["rt"] }
-tokio-util = { version = "0.7.10", features = ["io", "io-util"] }
+anyhow = "1.0.86"
+regex = "1.10.5"
+tokio = { version = "1.38.0", features = ["rt"] }
+tokio-util = { version = "0.7.11", features = ["io", "io-util"] }
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
     "ext-anymap",
     "ext-http",

--- a/crates/manas_repo/src/layer/mod.rs
+++ b/crates/manas_repo/src/layer/mod.rs
@@ -17,11 +17,9 @@ pub trait LayeredRepo<Inner: Repo>:
         Inner::ResourceStatusTokenTypes,
         Self,
     >,
-    Context = Self::LayeredContext,
+    Context: LayeredRepoContext<InnerRepo = Inner, Repo = Self>,
 >
 {
-    /// Type of it's context
-    type LayeredContext: LayeredRepoContext<InnerRepo = Inner, Repo = Self>;
 }
 
 /// A trait for the repo layers.
@@ -50,8 +48,7 @@ where
             IR::ResourceStatusTokenTypes,
             Self,
         >,
+        Context: LayeredRepoContext<InnerRepo = IR, Repo = LR>,
     >,
-    LR::Context: LayeredRepoContext<InnerRepo = IR, Repo = LR>,
 {
-    type LayeredContext = LR::Context;
 }

--- a/crates/manas_repo/src/policy/uri/mod.rs
+++ b/crates/manas_repo/src/policy/uri/mod.rs
@@ -20,14 +20,14 @@ pub trait RepoUriPolicy: Clone + Send + Sync + 'static + RepoContextual {
 
     /// Get the mutex normal hash for given res uri.
     /// This method doesn't guarantee res uri is conformant to
-    /// it's uri policy.
+    /// repo's uri policy.
     fn mutex_normal_res_uri_hash(&self, res_uri: &SolidResourceUri) -> String;
 
     /// This method suggests a uri for a new child resource,
     /// given it's parent resource uri and a slug_hint.
     /// This method's semantics are purely advisory.
     /// It only guarantees that returned uri is a valid child
-    /// res uri as per space's naming policy.
+    /// res uri as per repo's naming policy.
     fn suggest_res_uri(
         &self,
         parent_res_uri: &SolidResourceUri,
@@ -36,10 +36,10 @@ pub trait RepoUriPolicy: Clone + Send + Sync + 'static + RepoContextual {
     ) -> Result<SolidResourceUri, BoxError>;
 
     /// Check if given relative resource slot path is allowed as
-    /// per space's uri policy.
+    /// per repo's uri policy.
     /// It only guarantees that all uris are valid and can be
     /// assigned to resources in a  slot path in that order, in
-    /// conformance with naming policy of the space.
+    /// conformance with naming policy of the repo.
     fn is_allowed_relative_slot_path(
         &self,
         relative_slot_path: &RelativeSolidResourceSlotPath<'_, <Self::Repo as Repo>::StSpace>,

--- a/crates/manas_repo/src/service/resource_operator/common/rep_update_action.rs
+++ b/crates/manas_repo/src/service/resource_operator/common/rep_update_action.rs
@@ -1,7 +1,7 @@
 //! I define [`RepUpdateAction`].
 //!
 
-pub use hyper::body::SizeHint;
+pub use http_body::SizeHint;
 
 use crate::Repo;
 

--- a/crates/manas_repo_layers/Cargo.toml
+++ b/crates/manas_repo_layers/Cargo.toml
@@ -17,12 +17,11 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
 manas_space = { version = "0.1.0", path = "../manas_space" }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"]}
 futures = "0.3.30"
-hyper = "0.14.29"
 tower = {version = "0.4.13", features=["util"]}
 thiserror = "1.0.61"
 once_cell = "1.19.0"
-headers = "0.3.9"
-http = "0.2.12"
+headers = "0.4.0"
+http = "1.1.0"
 mime = "0.3.17"
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = [
     "async",
@@ -39,7 +38,7 @@ manas_repo = { version = "0.1.0", path = "../manas_repo" }
 if_chain = "1.0.2"
 tokio = { version = "1.38.0", features = ["rt"] }
 sophia_api = "0.8.0"
-anyhow = "1.0.86"
+# anyhow = "1.0.86"
 
 rdf_vocabularies = { version = "0.2.0", features = [
     "ns-rdf",

--- a/crates/manas_repo_layers/Cargo.toml
+++ b/crates/manas_repo_layers/Cargo.toml
@@ -17,12 +17,12 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
 manas_space = { version = "0.1.0", path = "../manas_space" }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"]}
 futures = "0.3.30"
-hyper = "0.14.28"
+hyper = "0.14.29"
 tower = {version = "0.4.13", features=["util"]}
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 once_cell = "1.19.0"
 headers = "0.3.9"
-http = "0.2.11"
+http = "0.2.12"
 mime = "0.3.17"
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = [
     "async",
@@ -37,9 +37,9 @@ typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", feature
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils"}
 manas_repo = { version = "0.1.0", path = "../manas_repo" }
 if_chain = "1.0.2"
-tokio = { version = "1.36.0", features = ["rt"] }
+tokio = { version = "1.38.0", features = ["rt"] }
 sophia_api = "0.8.0"
-anyhow = "1.0.79"
+anyhow = "1.0.86"
 
 rdf_vocabularies = { version = "0.2.0", features = [
     "ns-rdf",

--- a/crates/manas_repo_layers/Cargo.toml
+++ b/crates/manas_repo_layers/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_repo_layers"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides implementations for few common repo layers that integrate into manas eco system."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_repo_layers/src/dconneging/conneg_layer/impl_/binary_rdf_doc_converting.rs
+++ b/crates/manas_repo_layers/src/dconneging/conneg_layer/impl_/binary_rdf_doc_converting.rs
@@ -91,8 +91,6 @@ where
 {
     type Config = BinaryRdfDocContentNegotiationConfig;
 
-    type WService = BinaryRdfDocContentNegotiatingResourceReader<R, S>;
-
     fn new(config: Arc<Self::Config>) -> Self {
         Self {
             config,

--- a/crates/manas_repo_layers/src/dconneging/conneg_layer/impl_/constant_overriding.rs
+++ b/crates/manas_repo_layers/src/dconneging/conneg_layer/impl_/constant_overriding.rs
@@ -119,8 +119,6 @@ where
 {
     type Config = Option<ConstantOverrideNegotiationConfig>;
 
-    type WService = ConstantOverrideNegotiatingResourceReader<R, S>;
-
     fn new(config: Arc<Self::Config>) -> Self {
         Self {
             config,

--- a/crates/manas_repo_layers/src/dconneging/conneg_layer/impl_/stack.rs
+++ b/crates/manas_repo_layers/src/dconneging/conneg_layer/impl_/stack.rs
@@ -35,11 +35,9 @@ where
     ORep: Representation + Send + 'static,
     S: FlexibleResourceReader<R, R::Representation>,
     Inner: DerivedContentNegotiationLayer<R, R::Representation, S>,
-    Outer: DerivedContentNegotiationLayer<R, ORep, Inner::WService>,
+    Outer: DerivedContentNegotiationLayer<R, ORep, Inner::Service>,
 {
     type Config = StackConfig<Inner::Config, Outer::Config>;
-
-    type WService = Outer::WService;
 
     fn new(config: Arc<Self::Config>) -> Self {
         Self::new(

--- a/crates/manas_repo_layers/src/dconneging/conneg_layer/mod.rs
+++ b/crates/manas_repo_layers/src/dconneging/conneg_layer/mod.rs
@@ -11,7 +11,7 @@ pub mod impl_;
 
 /// A trait for derived content negotiation layers.
 pub trait DerivedContentNegotiationLayer<R, LRep, S>:
-    Debug + Layer<S, Service = Self::WService> + Send + 'static
+    Debug + Layer<S, Service: FlexibleResourceReader<R, LRep>> + Send + 'static
 where
     R: Repo,
     LRep: Representation + Send + 'static,
@@ -19,9 +19,6 @@ where
 {
     /// Type of the layer config.
     type Config: Debug + Send + Sync + 'static;
-
-    /// Type of wrapped services.
-    type WService: FlexibleResourceReader<R, LRep>;
 
     /// Create a new layer with given config.
     fn new(config: Arc<Self::Config>) -> Self;

--- a/crates/manas_repo_layers/src/patching/patcher/impl_/solid_insert_delete_patcher.rs
+++ b/crates/manas_repo_layers/src/patching/patcher/impl_/solid_insert_delete_patcher.rs
@@ -9,13 +9,16 @@ use dyn_problem::{
     type_::{INTERNAL_ERROR, UNKNOWN_IO_ERROR},
     ProbFuture, Problem,
 };
-use manas_http::representation::{
-    impl_::{
-        basic::BasicRepresentation,
-        binary::BinaryRepresentation,
-        common::data::{bytes_inmem::BytesInmem, quads_inmem::QuadsInmem},
+use manas_http::{
+    representation::{
+        impl_::{
+            basic::BasicRepresentation,
+            binary::BinaryRepresentation,
+            common::data::{bytes_inmem::BytesInmem, quads_inmem::QuadsInmem},
+        },
+        Representation,
     },
-    Representation,
+    BoxError,
 };
 use manas_repo::service::{
     patcher_resolver::{
@@ -187,9 +190,9 @@ where
             let patch_rep_inmem: BinaryRepresentation<BytesInmem> =
                 async_convert::TryFrom::try_from(patch_doc_rep)
                     .await
-                    .map_err(|e: anyhow::Error| {
+                    .map_err(|e: BoxError| {
                         error!("Error in loading patch body into memory. Error:\n {}", e);
-                        if e.is::<OutOfSizeLimitError>() {
+                        if e.downcast_ref::<OutOfSizeLimitError>().is_some() {
                             PAYLOAD_TOO_LARGE
                                 .new_problem_builder()
                                 .message("Patch payload too large.")

--- a/crates/manas_repo_opendal/Cargo.toml
+++ b/crates/manas_repo_opendal/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_repo_opendal"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides default repository implementation on top of [OpenDAL](https://docs.rs/opendal/latest/opendal/) object store abstraction layer for manas ecosystem."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_repo_opendal/Cargo.toml
+++ b/crates/manas_repo_opendal/Cargo.toml
@@ -16,10 +16,10 @@ once_cell = "1.19.0"
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = [
     "async",
 ] }
-tokio = { version = "1.36.0", features = ["rt", "macros", "io-util"] }
+tokio = { version = "1.38.0", features = ["rt", "macros", "io-util"] }
 tower = { version = "0.4.13", features = ["util"] }
 tracing = { version = "0.1.40", features = ["attributes"] }
-uuid = { version = "1.7.0", features = ["v4"] }
+uuid = { version = "1.9.1", features = ["v4"] }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = [
     "ext-typed-record",
 ] }
@@ -31,23 +31,23 @@ rand = "0.8.5"
 rand_seeder = "0.2.3"
 if_chain = "1.0.2"
 bimap = "0.6.3"
-thiserror = "1.0.56"
-flagset = "0.4.4"
+thiserror = "1.0.61"
+flagset = "0.4.5"
 # Opendal is pinned, as it breaks frequently.
 opendal = { version = "^0.44.2", features = ["rustls"]}
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
-regex = "1.10.3"
+regex = "1.10.5"
 percent-encoding = "2.3.1"
 async-stream = "0.3.5"
-smallvec = "1.13.1"
-serde = { version = "1.0.196", features = ["derive"] }
-serde_with = { version = "3.6.0", features = ["time_0_3"] }
+smallvec = "1.13.2"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_with = { version = "3.8.3", features = ["time_0_3"] }
 headers = "0.3.9"
-serde_json = "1.0.113"
-anyhow = "1.0.79"
-either = "1.9.0"
-bytes = "1.5.0"
-async-trait = "0.1.77"
+serde_json = "1.0.120"
+anyhow = "1.0.86"
+either = "1.13.0"
+bytes = "1.6.0"
+async-trait = "0.1.80"
 rdf_vocabularies = { version = "0.2.0", features = [
     "ns-solid",
     "ns-ldp",
@@ -69,24 +69,24 @@ typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", feature
 ] }
 async-once-cell = "0.5.3"
 http-body = "0.4.6"
-hyper = { version = "0.14.28", features = ["stream"] }
+hyper = { version = "0.14.29", features = ["stream"] }
 manas_space = { version = "0.1.0", path = "../manas_space"}
-vec1 = "1.10.1"
-chrono = { version = "0.4.33", default-features = false, features = ["serde"] }
+vec1 = "1.12.1"
+chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
 mime = "0.3.17"
 itertools = "0.11.0"
 sophia_turtle = "0.8.0"
 manas_semslot = { version = "0.1.0", path = "../manas_semslot"}
-mime_guess = { version = "2.0.4"}
+mime_guess = { version = "2.0.5"}
 
 # feature; service-embedded
-rust-embed = { version = "8.2.0", optional = true }
+rust-embed = { version = "8.4.0", optional = true }
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }
 rstest = { version = "0.18.2", optional = true }
 build-fs-tree = { version = "0.6.0", optional = false }
-async-recursion = { version = "1.0.5", optional = false }
+async-recursion = { version = "1.1.1", optional = false }
 hex = "0.4.3"
 webid = { version = "0.1.0", path = "../../fcrates/webid", features = ["sophia"] }
 
@@ -96,7 +96,7 @@ unwrap-infallible = "0.1.5"
 acp = { version = "0.1.0", path = "../../fcrates/acp", optional = true }
 async-convert = "1.0.0"
 manas_authentication = { version = "0.1.0", path = "../manas_authentication" }
-ecow = "0.2.0"
+ecow = "0.2.2"
 capped_stream = { version = "0.1.1", path = "../../fcrates/capped_stream" }
 
 
@@ -111,7 +111,7 @@ access-prp = ["dep:manas_access_control", "dep:acp"]
 [dev-dependencies]
 claims = "0.7.1"
 rstest = "0.18.2"
-tracing-test = "0.2.4"
+tracing-test = "0.2.5"
 manas_semslot = { version = "0.1.0", path = "../manas_semslot", features = ["test-utils"] }
 
 [package.metadata.docs.rs]

--- a/crates/manas_repo_opendal/Cargo.toml
+++ b/crates/manas_repo_opendal/Cargo.toml
@@ -42,7 +42,7 @@ async-stream = "0.3.5"
 smallvec = "1.13.2"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_with = { version = "3.8.3", features = ["time_0_3"] }
-headers = "0.3.9"
+headers = "0.4.0"
 serde_json = "1.0.120"
 anyhow = "1.0.86"
 either = "1.13.0"
@@ -63,18 +63,17 @@ rdf_vocabularies = { version = "0.2.0", features = [
     "ns-dcterms",
 ] }
 sophia_api = "0.8.0"
-dashmap = "5.5.3"
+dashmap = "6.0.1"
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
     "ext-anymap",
 ] }
 async-once-cell = "0.5.3"
-http-body = "0.4.6"
-hyper = { version = "0.14.29", features = ["stream"] }
+http-body = "1.0.0"
 manas_space = { version = "0.1.0", path = "../manas_space"}
 vec1 = "1.12.1"
 chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
 mime = "0.3.17"
-itertools = "0.11.0"
+itertools = "0.13.0"
 sophia_turtle = "0.8.0"
 manas_semslot = { version = "0.1.0", path = "../manas_semslot"}
 mime_guess = { version = "2.0.5"}
@@ -84,7 +83,7 @@ rust-embed = { version = "8.4.0", optional = true }
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }
-rstest = { version = "0.18.2", optional = true }
+rstest = { version = "0.21.0", optional = true }
 build-fs-tree = { version = "0.6.0", optional = false }
 async-recursion = { version = "1.1.1", optional = false }
 hex = "0.4.3"
@@ -110,7 +109,7 @@ access-prp = ["dep:manas_access_control", "dep:acp"]
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 tracing-test = "0.2.5"
 manas_semslot = { version = "0.1.0", path = "../manas_semslot", features = ["test-utils"] }
 

--- a/crates/manas_repo_opendal/src/object_store/backend/impl_/embedded/service.rs
+++ b/crates/manas_repo_opendal/src/object_store/backend/impl_/embedded/service.rs
@@ -108,6 +108,7 @@ impl<Assets: RustEmbed> EmbeddedAccessor<Assets> {
     }
 }
 
+/// Applies range over given bytes.
 fn apply_range(mut bs: Bytes, br: BytesRange) -> Bytes {
     match (br.offset(), br.size()) {
         (Some(offset), Some(size)) => {

--- a/crates/manas_repo_opendal/src/object_store/backend/impl_/embedded/service.rs
+++ b/crates/manas_repo_opendal/src/object_store/backend/impl_/embedded/service.rs
@@ -167,7 +167,7 @@ impl<Assets: RustEmbed + Send + Sync + 'static> Accessor for EmbeddedAccessor<As
 
     fn info(&self) -> AccessorInfo {
         let mut info = AccessorInfo::default();
-        info.set_scheme(opendal::Scheme::Custom("Embedded"))
+        info.set_scheme(Scheme::Custom("Embedded"))
             .set_name(self.name.as_str())
             .set_native_capability(Capability {
                 stat: true,

--- a/crates/manas_repo_opendal/src/object_store/object/invariant.rs
+++ b/crates/manas_repo_opendal/src/object_store/object/invariant.rs
@@ -9,7 +9,7 @@ use futures::{stream::BoxStream, StreamExt, TryFutureExt, TryStreamExt};
 use gdp_rs::{binclassified::BinaryClassified, Proven};
 use manas_http::{
     header::common::media_type::MediaType,
-    representation::impl_::common::data::bytes_stream::BoxBytesStream,
+    representation::impl_::common::data::bytes_stream::BoxBytesStream, BoxError,
 };
 use opendal::{EntryMode, Lister, Writer};
 use tracing::{error, warn};
@@ -101,7 +101,7 @@ impl<'id, OstSetup: ODRObjectStoreSetup> ODRFileObjectExt<OstSetup>
                 .reader_with(self.backend_entry.path())
                 .range(range)
                 .await?
-                .err_into::<anyhow::Error>(),
+                .err_into::<BoxError>(),
         ) as BoxStream<_>)
     }
 
@@ -111,7 +111,7 @@ impl<'id, OstSetup: ODRObjectStoreSetup> ODRFileObjectExt<OstSetup>
                 .operator()
                 .reader(self.backend_entry.path())
                 .await?
-                .err_into::<anyhow::Error>(),
+                .err_into::<BoxError>(),
         ) as BoxStream<_>)
     }
 

--- a/crates/manas_repo_opendal/src/object_store/object_space/mod.rs
+++ b/crates/manas_repo_opendal/src/object_store/object_space/mod.rs
@@ -461,7 +461,7 @@ mod tests {
         #[case] res_uri_str: &str,
         #[case] expectation: Result<Vec<(AssocRelType, &str)>, ODRAssocMappingError>,
     ) {
-        let obj_space = mock::MockODRObjectSpace::<0>::new_mock(assoc_storage_root_uri_str);
+        let obj_space = MockODRObjectSpace::<0>::new_mock(assoc_storage_root_uri_str);
 
         let links_result_flattened = obj_space
             .assoc_links_for_res(

--- a/crates/manas_repo_opendal/src/object_store/util/object_tree_sketch.rs
+++ b/crates/manas_repo_opendal/src/object_store/util/object_tree_sketch.rs
@@ -46,10 +46,13 @@ impl<'s> ODRObjectTreeSketch<'s> {
 
     /// Setup the tree represented by this sketch in given object store.
     #[async_recursion]
-    pub async fn setup<OstSetup: ODRObjectStoreSetup>(
+    pub async fn setup<OstSetup>(
         &self,
         object_store: &ODRObjectStore<OstSetup>,
-    ) -> Result<(), BoxError> {
+    ) -> Result<(), BoxError>
+    where
+        OstSetup: ODRObjectStoreSetup,
+    {
         let root_odr_object = object_store.odr_object(self.tree_root_path.clone())?;
 
         match self.tree_content_sketch.as_ref() {

--- a/crates/manas_repo_opendal/src/service/resource_operator/common/status_token/inputs/container_index.rs
+++ b/crates/manas_repo_opendal/src/service/resource_operator/common/status_token/inputs/container_index.rs
@@ -120,7 +120,7 @@ impl<Setup: ODRSetup> ODRContainerIndexInputs<Setup> {
                         // Skip if there is any error.
                         error!("Error in listing odr object. Error:\n {}", e);
                         // Yield error.
-                        yield Err(anyhow::Error::from(e));
+                        yield Err(e.into());
                         continue
                     }
                 };

--- a/crates/manas_semslot/Cargo.toml
+++ b/crates/manas_semslot/Cargo.toml
@@ -17,12 +17,12 @@ thiserror = "1.0.61"
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }
-rstest = { version = "0.18.2", optional = true }
+rstest = { version = "0.21.0", optional = true }
 
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 manas_http = { version = "0.1.1", path = "../manas_http", features = [
     "test-utils",
 ] }

--- a/crates/manas_semslot/Cargo.toml
+++ b/crates/manas_semslot/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_semslot"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "It is a bad idea to encode extra semantics into opaque resource ids as part of an http engine logic. But it is ok to do so behind a linked architecture abstraction, as an implementation detail for the sake of efficiency to avoid remote lookup. For such cases, this crate provides a type driven codec for encoding and decoding a solid resource slot path into/from it's slot id."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_semslot/Cargo.toml
+++ b/crates/manas_semslot/Cargo.toml
@@ -12,8 +12,8 @@ if_chain = "1.0.2"
 manas_http = { version = "0.1.1", path = "../manas_http" }
 manas_space = { version = "0.1.0", path = "../manas_space" }
 once_cell = "1.19.0"
-smallvec = "1.13.1"
-thiserror = "1.0.56"
+smallvec = "1.13.2"
+thiserror = "1.0.61"
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }

--- a/crates/manas_server/Cargo.toml
+++ b/crates/manas_server/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/manomayam/manas"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-http = "0.2.11"
+http = "0.2.12"
 manas_podverse = { version = "0.1.0", path = "../manas_podverse" }
 manas_repo = { version = "0.1.0", path = "../manas_repo" }
 manas_repo_opendal = { version = "0.1.0", path = "../manas_repo_opendal", features = ["access-prp", "backend-embedded"]}
@@ -19,17 +19,17 @@ tracing = { version = "0.1.40", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt", "ansi"] }
 tracing-log = "0.1.4"
 manas_http = { version = "0.1.1", path = "../manas_http" }
-flagset = "0.4.4"
-hyper = { version = "0.14.28", features = ["server", "stream"] }
+flagset = "0.4.5"
+hyper = { version = "0.14.29", features = ["server", "stream"] }
 tower-http = { version = "0.4.4", features = ["cors", "catch-panic"] }
 manas_space = { version = "0.1.0", path = "../manas_space" }
 once_cell = "1.19.0"
-serde = { version = "1.0.196", features = ["derive"] }
-bytes = { version = "1.5.0" }
+serde = { version = "1.0.203", features = ["derive"] }
+bytes = { version = "1.6.0" }
 mime = { version = "0.3.17" }
 tower = { version = "0.4.13", features = ["make", "util"] }
 webid = { version = "0.1.0", path = "../../fcrates/webid" }
-rust-embed = { version = "8.2.0" }
+rust-embed = { version = "8.4.0" }
 # Opendal is pinned, as it breaks frequently.
 opendal = {version = "^0.44.2", features = ["rustls"]}
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
@@ -45,18 +45,18 @@ upon = { version = "0.7.1", default-features = false, features = ["serde"] }
 futures = "0.3.30"
 axum-server = { version = "0.5.1", features = ["tls-rustls"] }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"] }
-anyhow = "1.0.79"
-clap = { version = "4.4.18", features = [
+anyhow = "1.0.86"
+clap = { version = "4.5.8", features = [
     "derive", "string"
 ] }
 config = { version = "0.14.0", default-features = false, features = ["toml"] }
-tokio = { version = "1.36.0", features = ["fs"] }
+tokio = { version = "1.38.0", features = ["fs"] }
 dpop = { version = "0.1.1", path = "../../fcrates/dpop", features = ["unsafe-optional-ath-claim"] }
-paste = "1.0.14"
+paste = "1.0.15"
 manas_authentication = { version = "0.1.0", path = "../manas_authentication" }
 manas_repo_layers = { version = "0.1.0", path = "../manas_repo_layers", features = ["dconneging", "patching", "validating"] }
 frunk_core = "0.4.2"
-serde_with = "3.6.0"
+serde_with = "3.8.3"
 http-cache-reqwest = { version = "0.12.0", default-features = false, features = ["manager-moka"] }
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = ["jsonld-http-loader"] }
 sophia_turtle = "0.8.0"

--- a/crates/manas_server/Cargo.toml
+++ b/crates/manas_server/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/manomayam/manas"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-http = "0.2.12"
+http = "1.1.0"
 manas_podverse = { version = "0.1.0", path = "../manas_podverse" }
 manas_repo = { version = "0.1.0", path = "../manas_repo" }
 manas_repo_opendal = { version = "0.1.0", path = "../manas_repo_opendal", features = ["access-prp", "backend-embedded"]}
@@ -17,11 +17,12 @@ name_locker = { version = "0.1.1", path = "../../fcrates/name_locker", features 
 ] }
 tracing = { version = "0.1.40", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt", "ansi"] }
-tracing-log = "0.1.4"
-manas_http = { version = "0.1.1", path = "../manas_http" }
+tracing-log = "0.2.0"
+manas_http = { version = "0.1.1", path = "../manas_http", features = ["body", "hyper"]}
 flagset = "0.4.5"
-hyper = { version = "0.14.29", features = ["server", "stream"] }
-tower-http = { version = "0.4.4", features = ["cors", "catch-panic"] }
+# TODO: Should be updated after axum-server update.
+hyper = { version = "1.0", features = ["server"] }
+tower-http = { version = "0.5.2", features = ["cors", "catch-panic"] }
 manas_space = { version = "0.1.0", path = "../manas_space" }
 once_cell = "1.19.0"
 serde = { version = "1.0.203", features = ["derive"] }
@@ -41,9 +42,9 @@ manas_access_control = { version = "0.1.0", path = "../manas_access_control", fe
 ] }
 rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils" }
 manas_semslot = { version = "0.1.0", path = "../manas_semslot" }
-upon = { version = "0.7.1", default-features = false, features = ["serde"] }
+upon = { version = "0.8.1", default-features = false, features = ["serde"] }
 futures = "0.3.30"
-axum-server = { version = "0.5.1", features = ["tls-rustls"] }
+axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["alias-future"] }
 anyhow = "1.0.86"
 clap = { version = "4.5.8", features = [
@@ -57,7 +58,7 @@ manas_authentication = { version = "0.1.0", path = "../manas_authentication" }
 manas_repo_layers = { version = "0.1.0", path = "../manas_repo_layers", features = ["dconneging", "patching", "validating"] }
 frunk_core = "0.4.2"
 serde_with = "3.8.3"
-http-cache-reqwest = { version = "0.12.0", default-features = false, features = ["manager-moka"] }
+http-cache-reqwest = { version = "0.14.0", default-features = false, features = ["manager-moka"] }
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn", features = ["jsonld-http-loader"] }
 sophia_turtle = "0.8.0"
 

--- a/crates/manas_server/Cargo.toml
+++ b/crates/manas_server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_server"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides default recipes of solid server."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_server/recipes/single_fs_noauth/Cargo.toml
+++ b/crates/manas_server/recipes/single_fs_noauth/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_server_single_fs_noauth"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This binary crate provides a solid server with fs backend, without authentication requirements."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_server/recipes/single_fs_noauth/Cargo.toml
+++ b/crates/manas_server/recipes/single_fs_noauth/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 manas_server = { version = "0.1.0", path = "../..", features = ["backend-fs"] }
-tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread"] }
 
 
 [package.metadata.docs.rs]

--- a/crates/manas_server/recipes/single_fs_wac/Cargo.toml
+++ b/crates/manas_server/recipes/single_fs_wac/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_server_single_fs_wac"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This binary crate provides a solid server with fs backend, with wac access control."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_server/recipes/single_fs_wac/Cargo.toml
+++ b/crates/manas_server/recipes/single_fs_wac/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 manas_server = { version = "0.1.0", path = "../..", features = ["backend-fs", "pdp-wac"] }
-tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread"] }
 
 
 [package.metadata.docs.rs]

--- a/crates/manas_server/recipes/single_s3_wac/Cargo.toml
+++ b/crates/manas_server/recipes/single_s3_wac/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 manas_server = { version = "0.1.0", path = "../..", features = ["backend-s3", "pdp-wac"] }
-tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["rt", "rt-multi-thread"] }
 
 
 [package.metadata.docs.rs]

--- a/crates/manas_server/recipes/single_s3_wac/Cargo.toml
+++ b/crates/manas_server/recipes/single_s3_wac/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_server_single_s3_wac"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This binary crate provides a solid server with s3 backend, with wac access control."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_server/src/dtbr.rs
+++ b/crates/manas_server/src/dtbr.rs
@@ -5,23 +5,19 @@
 use std::sync::Arc;
 
 use manas_http::{
-    header::common::qvalue::QValue,
-    representation::impl_::{binary::BinaryRepresentation, common::data::bytes_inmem::BytesInmem},
+    header::common::qvalue::QValue, representation::impl_::common::data::bytes_inmem::BytesInmem,
     uri::invariant::AbsoluteHttpUri,
 };
-use manas_repo_layers::dconneging::conneg_layer::{
-    impl_::{
-        constant_overriding::{
-            ConstantOverrideNegotiationConfig, ConstantOverrideNegotiationLayer,
-            ConstantOverridingPreferences,
-        },
-        stack::StackConfig,
+use manas_repo_layers::dconneging::conneg_layer::impl_::{
+    constant_overriding::{
+        ConstantOverrideNegotiationConfig, ConstantOverrideNegotiationLayer,
+        ConstantOverridingPreferences,
     },
-    DerivedContentNegotiationLayer,
+    stack::StackConfig,
 };
 use manas_repo_opendal::service::resource_operator::reader::ODRResourceReader;
 use once_cell::sync::Lazy;
-use tower::layer::util::Stack;
+use tower::{layer::util::Stack, Layer};
 use upon::Engine;
 
 use crate::repo::{RcpBaseRepo, RcpBaseRepoSetup, RcpRdfSourceCNL};
@@ -77,11 +73,7 @@ pub type DatabrowserAdaptedCNL<Backend, Inner> = Stack<
     Inner,
     ConstantOverrideNegotiationLayer<
         RcpBaseRepo<Backend>,
-        <Inner as DerivedContentNegotiationLayer<
-            RcpBaseRepo<Backend>,
-            BinaryRepresentation,
-            ODRResourceReader<RcpBaseRepoSetup<Backend>>,
-        >>::WService,
+        <Inner as Layer<ODRResourceReader<RcpBaseRepoSetup<Backend>>>>::Service,
     >,
 >;
 

--- a/crates/manas_server/src/pep.rs
+++ b/crates/manas_server/src/pep.rs
@@ -46,7 +46,7 @@ pub type RcpSimplePEP<Backend, PDP> =
 pub trait SimpleAccessRcpStorageSetup:
     RcpStorageSetup<PEP = RcpSimplePEP<Self::Backend_, Self::PDP>, Backend = Self::Backend_>
 {
-    /// Type of the backend.
+    /// Same as Self::Backend, but to avoid rrustc resolution cycle.
     type Backend_: ODRObjectStoreBackend;
 
     /// Type of the pdp.
@@ -60,7 +60,6 @@ impl<
     > SimpleAccessRcpStorageSetup for S
 {
     type Backend_ = Backend;
-
     type PDP = PDP;
 }
 
@@ -95,7 +94,7 @@ pub fn resolve_initial_root_acr_content(
     engine
         .get_template("initial_root_acr")
         .expect("Template must exist")
-        .render(&context)
+        .render(context)
         .to_string()
         .expect("Must be valid")
 }

--- a/crates/manas_server/src/storage.rs
+++ b/crates/manas_server/src/storage.rs
@@ -229,11 +229,11 @@ impl<StSetup: RcpStorageSetup> RcpStorage<StSetup> {
 
     /// Create a new [`RcpStorage`] with [``RcpSimplePEP`] as pep..
     pub fn new_with_simple_pep<
-        Backend: ODRObjectStoreBackend,
+        // Backend: ODRObjectStoreBackend,
         PDP: PolicyDecisionPoint<StSpace = RcpStorageSpace, Graph = HashSet<ArcTriple>>,
     >(
         storage_space: Arc<RcpStorageSpace>,
-        backend: StSetup::Backend,
+        backend: <StSetup as RcpStorageSetup>::Backend,
         odr_config: ODRConfig,
         conneg_layer_config: Arc<RcpCNLConfig<StSetup::CNL, StSetup::Backend>>,
         pdp: Arc<PDP>,
@@ -241,14 +241,16 @@ impl<StSetup: RcpStorageSetup> RcpStorage<StSetup> {
         resource_locker: StSetup::ResourceLocker,
     ) -> Self
     where
-        StSetup: SimpleAccessRcpStorageSetup<Backend_ = Backend, PDP = PDP>,
+        StSetup: SimpleAccessRcpStorageSetup<PDP = PDP>,
     {
         let odr_context = Arc::new(ODRContext::new(storage_space.clone(), backend, odr_config));
 
         let pep = RcpSimplePEP {
             storage_space,
             pdp,
-            prp: Arc::new(RcpPRP::<Backend>::new_with_context(odr_context.clone())),
+            prp: Arc::new(RcpPRP::<StSetup::Backend>::new_with_context(
+                odr_context.clone(),
+            )),
         };
 
         Self::_new(

--- a/crates/manas_space/Cargo.toml
+++ b/crates/manas_space/Cargo.toml
@@ -12,17 +12,17 @@ manas_http = { version = "0.1.1", path = "../manas_http", features = [
     "representation",
     "typed-headers",
 ] }
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 once_cell = "1.19.0"
-iri-string = "0.7.0"
-smallvec = "1.13.1"
-dyn-clone = "1.0.16"
+iri-string = "0.7.2"
+smallvec = "1.13.2"
+dyn-clone = "1.0.17"
 if_chain = "1.0.2"
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
 headers = "0.3.9"
-http = "0.2.11"
+http = "0.2.12"
 mime = "0.3.17"
-vec1 = "1.10.1"
+vec1 = "1.12.1"
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }

--- a/crates/manas_space/Cargo.toml
+++ b/crates/manas_space/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_space"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides abstractions for modelling storage spaces confirming to generalized solid protocol."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_space/Cargo.toml
+++ b/crates/manas_space/Cargo.toml
@@ -19,20 +19,20 @@ smallvec = "1.13.2"
 dyn-clone = "1.0.17"
 if_chain = "1.0.2"
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
-headers = "0.3.9"
-http = "0.2.12"
+headers = "0.4.0"
+http = "1.1.0"
 mime = "0.3.17"
 vec1 = "1.12.1"
 
 # feature: test-utils
 claims = { version = "0.7.1", optional = true }
-rstest = { version = "0.18.2", optional = true }
+rstest = { version = "0.21.0", optional = true }
 webid = { version = "0.1.0", path = "../../fcrates/webid" }
 
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 manas_http = { version = "0.1.1", path = "../manas_http", features = [
     "representation",
     "typed-headers",

--- a/crates/manas_specs/Cargo.toml
+++ b/crates/manas_specs/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["ext-typed-record"] }
-http = "0.2.12"
-http-api-problem = { version = "0.57.0", features = ["api-error"] }
+http = "1.1.0"
+http-api-problem = { version = "0.58.0", features = ["api-error"] }
 iri-string = "0.7.2"
 manas_http = { version = "0.1.1", path = "../manas_http" }
 once_cell = "1.19.0"

--- a/crates/manas_specs/Cargo.toml
+++ b/crates/manas_specs/Cargo.toml
@@ -8,15 +8,15 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = ["ext-typed-record"] }
-http = "0.2.11"
+http = "0.2.12"
 http-api-problem = { version = "0.57.0", features = ["api-error"] }
-iri-string = "0.7.0"
+iri-string = "0.7.2"
 manas_http = { version = "0.1.1", path = "../manas_http" }
 once_cell = "1.19.0"
 percent-encoding = "2.3.1"
-serde = "1.0.196"
-serde_with = "3.6.0"
-thiserror = "1.0.56"
+serde = "1.0.203"
+serde_with = "3.8.3"
+thiserror = "1.0.61"
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record" }
 
 [package.metadata.docs.rs]

--- a/crates/manas_specs/Cargo.toml
+++ b/crates/manas_specs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_specs"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides types to represent spec requirements, and exports statics for different specs in solid ecosystem."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_specs/codegen/Cargo.toml
+++ b/crates/manas_specs/codegen/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.79"
-serde_json = "1.0.113"
-iri-string = "0.7.0"
-syn = "2.0.48"
-regex = "1.10.3"
+anyhow = "1.0.86"
+serde_json = "1.0.120"
+iri-string = "0.7.2"
+syn = "2.0.68"
+regex = "1.10.5"
 once_cell = "1.19.0"
 rdf_vocabularies = { version = "0.2.0", features = ["ns-spec", "ns-dcterms"] }
-handlebars = "5.1.0"
-serde = { version = "1.0.196", features = ["derive"] }
+handlebars = "5.1.2"
+serde = { version = "1.0.203", features = ["derive"] }
 sophia_api = "0.8.0"
 rdf_utils = { version = "0.3.1", path = "../../../fcrates/rdf_utils" }
 sophia_turtle = "0.8.0"

--- a/crates/manas_specs/codegen/Cargo.toml
+++ b/crates/manas_specs/codegen/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_specs_codegen"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/manas_storage/Cargo.toml
+++ b/crates/manas_storage/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_storage"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides traits and implementations for a `SolidStorage`, and `SolidStorageService`, (a solid-protocol compatible http service over a storage)."
 repository = "https://github.com/manomayam/manas"

--- a/crates/manas_storage/Cargo.toml
+++ b/crates/manas_storage/Cargo.toml
@@ -17,15 +17,17 @@ either = "1.13.0"
 futures = "0.3.30"
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
 ghost = "0.1.17"
-headers = "0.3.9"
-http = "0.2.12"
-http-api-problem = { version = "0.57.0", features = ["api-error", "hyper"] }
-hyper = "0.14.29"
+headers = "0.4.0"
+http = "1.1.0"
+http-api-problem = { version = "0.58.0", features = ["api-error"] }
+http-body = "1.0.0"
 if_chain = "1.0.2"
 iri-string = "0.7.2"
 manas_access_control = { version = "0.1.0", path = "../manas_access_control" }
 manas_authentication = { version = "0.1.0", path = "../manas_authentication" }
 manas_http = { version = "0.1.1", path = "../manas_http", features = [
+    "body",
+    "problem",
     "service",
     "conditional_req",
 ] }
@@ -37,7 +39,9 @@ name_locker = { version = "0.1.1", path = "../../fcrates/name_locker" }
 once_cell = "1.19.0"
 rand = "0.8.5"
 rdf_dynsyn = { version = "0.4.0", path = "../../fcrates/rdf_dynsyn" }
-rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils", features = ["compat-iri-string"] }
+rdf_utils = { version = "0.3.1", path = "../../fcrates/rdf_utils", features = [
+    "compat-iri-string",
+] }
 rdf_vocabularies = { version = "0.2.0", features = [
     "ns-ldp",
     "ns-pim",
@@ -46,7 +50,7 @@ rdf_vocabularies = { version = "0.2.0", features = [
 sophia_api = "0.8.0"
 thiserror = "1.0.61"
 tower = "0.4.13"
-tower-http = { version = "0.4.4", features = ["cors"] }
+tower-http = { version = "0.5.2", features = ["cors"] }
 tracing = { version = "0.1.40", features = ["attributes"] }
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
     "ext-http",

--- a/crates/manas_storage/Cargo.toml
+++ b/crates/manas_storage/Cargo.toml
@@ -8,21 +8,21 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-anyhow = "1.0.79"
-dyn-clone = "1.0.16"
+anyhow = "1.0.86"
+dyn-clone = "1.0.17"
 dyn_problem = { version = "0.1.1", path = "../../fcrates/dyn_problem", features = [
     "ext-typed-record",
 ] }
-either = "1.9.0"
+either = "1.13.0"
 futures = "0.3.30"
 gdp_rs = { version = "0.1.1", path = "../../fcrates/gdp_rs" }
 ghost = "0.1.17"
 headers = "0.3.9"
-http = "0.2.11"
+http = "0.2.12"
 http-api-problem = { version = "0.57.0", features = ["api-error", "hyper"] }
-hyper = "0.14.28"
+hyper = "0.14.29"
 if_chain = "1.0.2"
-iri-string = "0.7.0"
+iri-string = "0.7.2"
 manas_access_control = { version = "0.1.0", path = "../manas_access_control" }
 manas_authentication = { version = "0.1.0", path = "../manas_authentication" }
 manas_http = { version = "0.1.1", path = "../manas_http", features = [
@@ -44,14 +44,14 @@ rdf_vocabularies = { version = "0.2.0", features = [
     "ns-solid",
 ] }
 sophia_api = "0.8.0"
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = { version = "0.1.40", features = ["attributes"] }
 typed_record = { version = "0.1.1", path = "../../fcrates/typed_record", features = [
     "ext-http",
 ] }
-vec1 = "1.10.1"
+vec1 = "1.12.1"
 
 
 [features]

--- a/crates/manas_storage/src/service/cors.rs
+++ b/crates/manas_storage/src/service/cors.rs
@@ -10,7 +10,7 @@ use http::{
     },
     HeaderName, Request, Response,
 };
-use hyper::Body;
+use manas_http::body::Body;
 use manas_http::{
     header::{
         accept_patch::ACCEPT_PATCH, accept_post::ACCEPT_POST, accept_put::ACCEPT_PUT,

--- a/crates/manas_storage/src/service/method/common/snippet/req_headers.rs
+++ b/crates/manas_storage/src/service/method/common/snippet/req_headers.rs
@@ -10,7 +10,7 @@ use http::{
     StatusCode,
 };
 use http_api_problem::ApiError;
-use hyper::body::SizeHint;
+use http_body::SizeHint;
 use manas_http::{
     header::common::media_type::MediaType, representation::metadata::derived_etag::DerivedETag,
 };

--- a/crates/manas_storage/src/service/method/delete/base/mod.rs
+++ b/crates/manas_storage/src/service/method/delete/base/mod.rs
@@ -8,8 +8,8 @@ use dyn_problem::{type_::INTERNAL_ERROR, Problem, ProblemBuilderExt};
 use futures::{future::BoxFuture, TryFutureExt};
 use http::{Method, Request, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
 use manas_access_control::model::{KResolvedAccessControl, KResolvedHostAccessControl};
+use manas_http::body::Body;
 use manas_http::uri::invariant::NormalAbsoluteHttpUri;
 use manas_repo::{
     policy::uri::RepoUriPolicy,

--- a/crates/manas_storage/src/service/method/delete/marshaller/default.rs
+++ b/crates/manas_storage/src/service/method/delete/marshaller/default.rs
@@ -6,8 +6,8 @@ use std::{convert::Infallible, sync::Arc, task::Poll};
 
 use http::{Response, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
 use manas_http::service::BoxHttpResponseFuture;
+use manas_http::{body::Body, problem::ApiErrorExt};
 use manas_repo::service::resource_operator::deleter::ResourceDeleteResponse;
 use tower::Service;
 
@@ -108,6 +108,6 @@ where
         if self.marshal_config.dev_mode {
             attach_authorization_context::<Storage>(&mut error);
         }
-        error.into_hyper_response()
+        error.into_http_response()
     }
 }

--- a/crates/manas_storage/src/service/method/get/base/mod.rs
+++ b/crates/manas_storage/src/service/method/get/base/mod.rs
@@ -12,8 +12,8 @@ use futures::{future::BoxFuture, TryFutureExt};
 use headers::{HeaderMap, HeaderMapExt};
 use http::{request::Parts, Method, Request, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
 use manas_access_control::model::KResolvedAccessControl;
+use manas_http::body::Body;
 use manas_http::{
     conditional_req::PreconditionsResolvedAction,
     representation::impl_::{

--- a/crates/manas_storage/src/service/method/get/marshaller/default.rs
+++ b/crates/manas_storage/src/service/method/get/marshaller/default.rs
@@ -7,10 +7,10 @@ use std::{convert::Infallible, sync::Arc, task::Poll};
 use headers::{AcceptRanges, ContentLength, ContentType, ETag, HeaderMapExt};
 use http::{header::VARY, Response, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
 use if_chain::if_chain;
 use iri_string::types::UriReferenceStr;
 use manas_access_control::model::KResolvedAccessControl;
+use manas_http::{body::Body, problem::HttpApiProblemExt};
 use manas_http::{
     header::link::{Link, LinkRel, LinkTarget, LinkValue},
     representation::{
@@ -271,7 +271,7 @@ where
         }
 
         builder
-            .body(Body::wrap_stream(
+            .body(Body::from_stream(
                 base_response
                     .state
                     .into_parts()
@@ -291,7 +291,7 @@ where
         }
 
         // Get hyper response.
-        let mut response = error.to_http_api_problem().to_hyper_response();
+        let mut response = error.to_http_api_problem().to_http_response();
 
         if response.status() == StatusCode::NOT_FOUND {
             // Check if mutex resource exists, and redirect instead of error if configured.

--- a/crates/manas_storage/src/service/method/get/marshaller/head_only.rs
+++ b/crates/manas_storage/src/service/method/get/marshaller/head_only.rs
@@ -68,7 +68,7 @@ where
         Box::pin(self.inner.call(req).map_ok(|resp| {
             // Replace body with empty body.
             let (parts, _body) = resp.into_parts();
-            Response::from_parts(parts, hyper::Body::empty())
+            Response::from_parts(parts, Body::empty())
         }))
     }
 }

--- a/crates/manas_storage/src/service/method/get/marshaller/head_only.rs
+++ b/crates/manas_storage/src/service/method/get/marshaller/head_only.rs
@@ -7,7 +7,7 @@ use std::{convert::Infallible, marker::PhantomData, task::Poll};
 use futures::TryFutureExt;
 use http::Response;
 use http_api_problem::ApiError;
-use hyper::Body;
+use manas_http::body::Body;
 use manas_http::service::BoxHttpResponseFuture;
 use tower::Service;
 

--- a/crates/manas_storage/src/service/method/mod.rs
+++ b/crates/manas_storage/src/service/method/mod.rs
@@ -10,7 +10,7 @@ use std::{
 use futures::{future::BoxFuture, FutureExt};
 use http::{Request, Response};
 use http_api_problem::ApiError;
-use hyper::Body;
+use manas_http::body::Body;
 use manas_http::service::BoxHttpResponseFuture;
 use tower::{Service, ServiceExt};
 

--- a/crates/manas_storage/src/service/method/post/base/mod.rs
+++ b/crates/manas_storage/src/service/method/post/base/mod.rs
@@ -9,8 +9,8 @@ use futures::{future::BoxFuture, TryFutureExt};
 use headers::HeaderMapExt;
 use http::{Method, Request, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
 use manas_access_control::model::{KResolvedAccessControl, KResolvedHostAccessControl};
+use manas_http::body::Body;
 use manas_http::{
     header::{
         link::{Link, LinkValue, TYPE_REL_TYPE},
@@ -222,7 +222,7 @@ where
             BasicRepresentation {
                 metadata: RepresentationMetadata::new()
                     .with::<KContentType>(resolve_req_content_type(&req_parts.headers)?),
-                data: BytesStream::from_hyper_body(
+                data: BytesStream::from_http_body(
                     body,
                     Some(resolve_req_content_length_hint(&req_parts.headers)),
                 ),

--- a/crates/manas_storage/src/service/method/post/marshaller/default.rs
+++ b/crates/manas_storage/src/service/method/post/marshaller/default.rs
@@ -7,7 +7,8 @@ use std::{convert::Infallible, sync::Arc, task::Poll};
 use headers::HeaderMapExt;
 use http::{Response, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
+use manas_http::body::Body;
+use manas_http::problem::ApiErrorExt;
 use manas_http::{
     header::link::{Link, LinkValue},
     service::BoxHttpResponseFuture,
@@ -147,6 +148,6 @@ where
             attach_authorization_context::<Storage>(&mut error);
         }
 
-        error.into_hyper_response()
+        error.into_http_response()
     }
 }

--- a/crates/manas_storage/src/service/method/put_or_patch/base/mod.rs
+++ b/crates/manas_storage/src/service/method/put_or_patch/base/mod.rs
@@ -8,9 +8,10 @@ use dyn_problem::{type_::INTERNAL_ERROR, Problem, ProblemBuilderExt};
 use futures::{future::BoxFuture, TryFutureExt};
 use http::{Method, Request, StatusCode};
 use http_api_problem::{ApiError, ApiErrorBuilder};
-use hyper::{body::SizeHint, Body};
+use http_body::SizeHint;
 use manas_access_control::model::{KResolvedAccessControl, KResolvedHostAccessControl};
 use manas_http::{
+    body::Body,
     conditional_req::PreconditionsResolvedAction,
     header::common::media_type::{MediaType, TEXT_TURTLE},
     representation::{
@@ -183,7 +184,7 @@ where
                 BasicRepresentation {
                     metadata: RepresentationMetadata::new()
                         .with::<KContentType>(payload_content_type),
-                    data: BytesStream::from_hyper_body(body, Some(payload_content_length_hint)),
+                    data: BytesStream::from_http_body(body, Some(payload_content_length_hint)),
                     base_uri: Some(res_uri.clone().into_subject()),
                 }
                 .into_binary(),
@@ -587,7 +588,7 @@ where
                         BasicRepresentation {
                             metadata: RepresentationMetadata::new()
                                 .with::<KContentType>(TEXT_TURTLE.clone()),
-                            data: BytesStream::from_hyper_body(
+                            data: BytesStream::from_http_body(
                                 Body::empty(),
                                 Some(SizeHint::with_exact(0)),
                             ),

--- a/crates/manas_storage/src/service/method/put_or_patch/marshaller/default.rs
+++ b/crates/manas_storage/src/service/method/put_or_patch/marshaller/default.rs
@@ -7,7 +7,8 @@ use std::{convert::Infallible, sync::Arc, task::Poll};
 use headers::{ETag, HeaderMapExt};
 use http::{Response, StatusCode};
 use http_api_problem::ApiError;
-use hyper::Body;
+use manas_http::body::Body;
+use manas_http::problem::ApiErrorExt;
 use manas_http::{representation::metadata::KDerivedETag, service::BoxHttpResponseFuture};
 use tower::Service;
 use typed_record::{TypedRecord, TypedRecordKey};
@@ -136,7 +137,7 @@ where
             }
         }
 
-        error.into_hyper_response()
+        error.into_http_response()
     }
 }
 

--- a/crates/manas_storage/src/service/mod.rs
+++ b/crates/manas_storage/src/service/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use dyn_problem::Problem;
 use futures::future::BoxFuture;
-use manas_http::service::namespaced::NamespacedHttpService;
+use manas_http::{body::Body, service::namespaced::NamespacedHttpService};
 use tower::Service;
 
 use crate::SolidStorage;
@@ -15,9 +15,7 @@ pub mod impl_;
 pub mod method;
 
 /// A trait for solid compliant storage services.
-pub trait SolidStorageService:
-    NamespacedHttpService<hyper::Body, hyper::Body> + StorageInitializer
-{
+pub trait SolidStorageService: NamespacedHttpService<Body, Body> + StorageInitializer {
     /// Type of the storage, this service serves.
     type Storage: SolidStorage;
 

--- a/crates/manas_tauri/Cargo.toml
+++ b/crates/manas_tauri/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "manas_tauri"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides utilities to integrate manas as a backend in tauri apps."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/acp/Cargo.toml
+++ b/fcrates/acp/Cargo.toml
@@ -9,11 +9,11 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 rdf_utils = { version = "0.3.1", path = "../rdf_utils" }
 rdf_vocabularies = { version = "0.2.0", features = ["ns-acp", "ns-acl"] }
-paste = { version = "1.0.14" }
+paste = { version = "1.0.15" }
 sophia_api = { version = "0.8.0" }
 
 # feature: engine
-dyn-clone = { version = "1.0.16", optional = true }
+dyn-clone = { version = "1.0.17", optional = true }
 dyn_problem = { version = "0.1.1", path = "../dyn_problem", optional = true, features = ["alias-future"]}
 futures = { version = "0.3.30", optional = true }
 ghost = { version = "0.1.17", optional = true }

--- a/fcrates/acp/Cargo.toml
+++ b/fcrates/acp/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "acp"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "An implementation of [access control policy](https://solid.github.io/authorization-panel/acp-specification/) concepts and engine for rust."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/capped_stream/Cargo.toml
+++ b/fcrates/capped_stream/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "capped_stream"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides types for size capped streams."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/capped_stream/Cargo.toml
+++ b/fcrates/capped_stream/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 futures = "0.3.30"
-pin-project-lite = "0.2.13"
-thiserror = "1.0.56"
+pin-project-lite = "0.2.14"
+thiserror = "1.0.61"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fcrates/dpop/Cargo.toml
+++ b/fcrates/dpop/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-base64 = "0.21.7"
+base64 = "0.22.1"
 canonical_json = "0.5.0"
 frunk_core = "0.4.2"
 gdp_rs = { version = "0.1.1", path = "../gdp_rs", features = ["serde"] }
-http = "0.2.12"
-http-serde = "1.1.3"
+http = "1.1.0"
+http-serde = "2.1.1"
 http_uri = { version = "1.0.1", path = "../http_uri", features = ["serde"] }
 once_cell = { version = "1.19.0" }
 picky = { version = "7.0.0-rc.8", default-features = false, features = [
@@ -27,8 +27,8 @@ uuid = { version = "1.9.1", features = ["v4"] }
 
 # feature: http-header
 bytes = { version = "1.6.0", optional = true }
-itertools = { version = "0.11.0", optional = true }
-headers = { version = "0.3.9", optional = true }
+itertools = { version = "0.13.0", optional = true }
+headers = { version = "0.4.0", optional = true }
 
 [features]
 http-header = ["dep:headers", "dep:bytes", "dep:itertools"]
@@ -37,7 +37,7 @@ unsafe-optional-ath-claim = []
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fcrates/dpop/Cargo.toml
+++ b/fcrates/dpop/Cargo.toml
@@ -12,21 +12,21 @@ base64 = "0.21.7"
 canonical_json = "0.5.0"
 frunk_core = "0.4.2"
 gdp_rs = { version = "0.1.1", path = "../gdp_rs", features = ["serde"] }
-http = "0.2.11"
+http = "0.2.12"
 http-serde = "1.1.3"
 http_uri = { version = "1.0.1", path = "../http_uri", features = ["serde"] }
 once_cell = { version = "1.19.0" }
 picky = { version = "7.0.0-rc.8", default-features = false, features = [
     "jose",
 ] }
-regex = { version = "1.10.3" }
-serde = { version = "1.0.196", features = ["derive"] }
-serde_json = "1.0.113"
-thiserror = "1.0.56"
-uuid = { version = "1.7.0", features = ["v4"] }
+regex = { version = "1.10.5" }
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.120"
+thiserror = "1.0.61"
+uuid = { version = "1.9.1", features = ["v4"] }
 
 # feature: http-header
-bytes = { version = "1.5.0", optional = true }
+bytes = { version = "1.6.0", optional = true }
 itertools = { version = "0.11.0", optional = true }
 headers = { version = "0.3.9", optional = true }
 

--- a/fcrates/dpop/Cargo.toml
+++ b/fcrates/dpop/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dpop"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "An implementation of DPoP for rust."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/dpop/src/proof/payload/jkt.rs
+++ b/fcrates/dpop/src/proof/payload/jkt.rs
@@ -1,3 +1,4 @@
+//! I provide types for representing jet key thumbprints.
 //!
 
 use std::ops::Deref;

--- a/fcrates/dyn_problem/Cargo.toml
+++ b/fcrates/dyn_problem/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dyn_problem"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides a `Problem` type to represent dynamic problems, with problem types identified by uri."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/dyn_problem/Cargo.toml
+++ b/fcrates/dyn_problem/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-http = "0.2.12"
-http-api-problem = {version = "0.57.0", features = ["api-error"]}
+http = "1.1.0"
+http-api-problem = {version = "0.58.0", features = ["api-error"]}
 iri-string = "0.7.2"
 once_cell = "1.19.0"
 

--- a/fcrates/dyn_problem/Cargo.toml
+++ b/fcrates/dyn_problem/Cargo.toml
@@ -8,16 +8,16 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-http = "0.2.11"
+http = "0.2.12"
 http-api-problem = {version = "0.57.0", features = ["api-error"]}
-iri-string = "0.7.0"
+iri-string = "0.7.2"
 once_cell = "1.19.0"
 
 # feature: ext-typed-record
 typed_record = { version = "0.1.1", path = "../typed_record", features = ["ext-http"], optional = true}
 
 # feature: anon-problem-type
-uuid = { version = "1.7.0", features = ["v4"], optional = true }
+uuid = { version = "1.9.1", features = ["v4"], optional = true }
 
 # feature: alias-future
 futures = { version = "0.3.30", optional = true }

--- a/fcrates/dyn_problem/src/lib.rs
+++ b/fcrates/dyn_problem/src/lib.rs
@@ -168,7 +168,7 @@ impl ProblemBuilder {
     ///
     /// Existing values will be overwritten
     #[inline]
-    pub fn extension<T: Send + Sync + 'static>(mut self, val: T) -> Self {
+    pub fn extension<T: Send + Sync + Clone + 'static>(mut self, val: T) -> Self {
         self.0 = self.0.extension(val);
         self
     }

--- a/fcrates/gdp_rs/Cargo.toml
+++ b/fcrates/gdp_rs/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-either = "1.9.0"
+either = "1.13.0"
 frunk_core = "0.4.2"
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 
 # feature: serde
-serde = { version = "1.0.196", optional = true }
+serde = { version = "1.0.203", optional = true }
 
 [features]
 serde = ["dep:serde"]

--- a/fcrates/gdp_rs/Cargo.toml
+++ b/fcrates/gdp_rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "gdp_rs"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "A library for implementing Ghosts-of-departed-proofs pattern in rust"
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/http_typed_headers/Cargo.toml
+++ b/fcrates/http_typed_headers/Cargo.toml
@@ -8,15 +8,15 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 once_cell = "1.19.0"
-regex = "1.10.3"
-thiserror = "1.0.56"
+regex = "1.10.5"
+thiserror = "1.0.61"
 tracing = { version = "0.1.40", features = ["attributes"] }
 unicase = { version = "2.7.0" }
-ecow = "0.2.0"
+ecow = "0.2.2"
 headers = { version = "0.3.9" }
-http = { version = "0.2.11" }
-smallvec = { version = "1.13.1" }
-vec1 = { version = "1.10.1", features = [
+http = { version = "0.2.12" }
+smallvec = { version = "1.13.2" }
+vec1 = { version = "1.12.1", features = [
     "smallvec-v1",
     "smallvec-v1-write",
 ] }
@@ -25,16 +25,16 @@ vec1 = { version = "1.10.1", features = [
 itertools = { version = "0.11.0", optional = true }
 
 # feature: www-authenticate
-either = { version = "1.9.0", optional = true }
+either = { version = "1.13.0", optional = true }
 
 # feature: media-type, accept-x
 mime = { version = "0.3.17", optional = true }
 
 # feature: qvalue, accept
-rust_decimal = { version = "1.34.2", optional = true }
+rust_decimal = { version = "1.35.0", optional = true }
 
 # feature: link, location
-iri-string = { version = "0.7.0", features = ["serde"], optional = true }
+iri-string = { version = "0.7.2", features = ["serde"], optional = true }
 
 # feature: slug
 percent-encoding = { version = "2.3.1", optional = true }

--- a/fcrates/http_typed_headers/Cargo.toml
+++ b/fcrates/http_typed_headers/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "http_typed_headers"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides few typed http headers."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/http_typed_headers/Cargo.toml
+++ b/fcrates/http_typed_headers/Cargo.toml
@@ -13,8 +13,8 @@ thiserror = "1.0.61"
 tracing = { version = "0.1.40", features = ["attributes"] }
 unicase = { version = "2.7.0" }
 ecow = "0.2.2"
-headers = { version = "0.3.9" }
-http = { version = "0.2.12" }
+headers = { version = "0.4.0" }
+http = { version = "1.1.0" }
 smallvec = { version = "1.13.2" }
 vec1 = { version = "1.12.1", features = [
     "smallvec-v1",
@@ -22,7 +22,7 @@ vec1 = { version = "1.12.1", features = [
 ] }
 
 # feature: location
-itertools = { version = "0.11.0", optional = true }
+itertools = { version = "0.13.0", optional = true }
 
 # feature: www-authenticate
 either = { version = "1.13.0", optional = true }
@@ -79,7 +79,7 @@ default = [
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fcrates/http_typed_headers/src/accept_patch/mod.rs
+++ b/fcrates/http_typed_headers/src/accept_patch/mod.rs
@@ -1,4 +1,4 @@
-//!
+//! I define typed header for `Accept-Patch`.
 use headers::{Header, HeaderName};
 use mime::Mime;
 use tracing::error;

--- a/fcrates/http_typed_headers/src/common/field/name.rs
+++ b/fcrates/http_typed_headers/src/common/field/name.rs
@@ -16,4 +16,4 @@ use super::rules::token::Token;
 ///
 ///
 /// [RFC 9110 Field Names]: https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names
-pub struct FieldName(Ascii<Token>);
+pub struct FieldName(pub Ascii<Token>);

--- a/fcrates/http_uri/Cargo.toml
+++ b/fcrates/http_uri/Cargo.toml
@@ -7,12 +7,12 @@ repository = "https://github.com/manomayam/manas"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-iri-string = "0.7.0"
+iri-string = "0.7.2"
 unicase = "2.7.0"
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 
 # feature: serde
-serde = { version = "1.0.196", optional = true }
+serde = { version = "1.0.203", optional = true }
 
 # feature: invariants
 gdp_rs = { version = "0.1.1", path = "../gdp_rs", optional = true }

--- a/fcrates/http_uri/Cargo.toml
+++ b/fcrates/http_uri/Cargo.toml
@@ -30,7 +30,7 @@ default = ["invariants"]
 
 [dev-dependencies]
 claims = "0.7.1"
-rstest = "0.18.2"
+rstest = "0.21.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fcrates/http_uri/Cargo.toml
+++ b/fcrates/http_uri/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "http_uri"
 version = "1.0.1"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides types for representing http uris and their invariants."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/name_locker/Cargo.toml
+++ b/fcrates/name_locker/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "name_locker"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides interface for asynchronous name lockers, that can run an async task with lock on a given name."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/name_locker/Cargo.toml
+++ b/fcrates/name_locker/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.30"
 
 # feature: inmem
 async-stream = { version = "0.3.5", optional = true }
-dashmap = { version = "5.5.3", optional = true }
+dashmap = { version = "6.0.1", optional = true }
 tokio = { version = "1.38.0", optional = true, features = ["sync"] }
 
 [features]

--- a/fcrates/name_locker/Cargo.toml
+++ b/fcrates/name_locker/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.30"
 # feature: inmem
 async-stream = { version = "0.3.5", optional = true }
 dashmap = { version = "5.5.3", optional = true }
-tokio = { version = "1.36.0", optional = true, features = ["sync"] }
+tokio = { version = "1.38.0", optional = true, features = ["sync"] }
 
 [features]
 inmem = ["dep:dashmap", "dep:tokio", "dep:async-stream"]

--- a/fcrates/name_locker/src/impl_/inmem.rs
+++ b/fcrates/name_locker/src/impl_/inmem.rs
@@ -11,6 +11,7 @@ use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use crate::{LockKind, NameLocker};
 
 /// An enum to hold lock guard.
+#[allow(dead_code)]
 enum LockGuard<'g> {
     Read(RwLockReadGuard<'g, ()>),
     Write(RwLockWriteGuard<'g, ()>),

--- a/fcrates/rdf_dynsyn/Cargo.toml
+++ b/fcrates/rdf_dynsyn/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rdf_dynsyn"
 version = "0.4.0"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides sophia-compatible and sophia-based rdf parsers/serializers, that can be instantiated against any of supported syntaxes dynamically at run time."
 keywords = ["rdf", "parse", "serialize", "sophia"]

--- a/fcrates/rdf_dynsyn/Cargo.toml
+++ b/fcrates/rdf_dynsyn/Cargo.toml
@@ -17,7 +17,7 @@ rio_turtle = "0.8.4"
 rio_api = "0.8.4"
 once_cell = "1.19.0"
 mime = "0.3.17"
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 tracing = "0.1.40"
 anymap2 = "0.13.0"
 gdp_rs = { version = "0.1.1", path = "../gdp_rs" }
@@ -33,18 +33,18 @@ rio_xml = { version = "0.8.4", optional = true }
 
 # feature: async
 futures = { version = "0.3.30", optional = true }
-bytes = { version = "1.5.0", optional = true }
-tokio = { version = "1.36.0", optional = true, features = [
+bytes = { version = "1.6.0", optional = true }
+tokio = { version = "1.38.0", optional = true, features = [
     "io-util",
     "sync",
     "rt",
 ] }
-async-compat = { version = "0.2.3", optional = true }
-tokio-util = { version = "0.7.10", optional = true, features = [
+async-compat = { version = "0.2.4", optional = true }
+tokio-util = { version = "0.7.11", optional = true, features = [
     "io-util",
     "io",
 ] }
-tokio-stream = { version = "0.1.14", optional = true }
+tokio-stream = { version = "0.1.15", optional = true }
 
 # feature: jsonld
 json-ld = { version = "^0.15.1", optional = true}
@@ -57,8 +57,8 @@ rdf-types = { version = "^0.15.4", optional = true }
 document-features = { version = "0.2.8", optional = true }
 
 # feature: jsonld-http-loader
-reqwest = { version = "0.11.24", optional = true, default-features = false }
-reqwest-middleware = { version = "0.2.4", optional = true }
+reqwest = { version = "0.11.27", optional = true, default-features = false }
+reqwest-middleware = { version = "0.2.5", optional = true }
 http_typed_headers = { version = "0.1.0", path = "../http_typed_headers", default-features = false, features = ["accept", "location", "link"], optional = true }
 headers = { version = "0.3.9", optional = true }
 iref = { version = "2.2", optional = true }
@@ -79,7 +79,7 @@ native-tls =["reqwest?/native-tls"]
 default = ["rdf-xml", "rustls-tls"]
 
 [dev-dependencies]
-env_logger = "0.11.1"
+env_logger = "0.11.3"
 tracing = { version = "0.1.40", features = ["log"] }
 sophia_isomorphism = "0.8.0"
 rstest = "0.18.2"

--- a/fcrates/rdf_dynsyn/Cargo.toml
+++ b/fcrates/rdf_dynsyn/Cargo.toml
@@ -57,10 +57,10 @@ rdf-types = { version = "^0.15.4", optional = true }
 document-features = { version = "0.2.8", optional = true }
 
 # feature: jsonld-http-loader
-reqwest = { version = "0.11.27", optional = true, default-features = false }
-reqwest-middleware = { version = "0.2.5", optional = true }
+reqwest = { version = "0.12.5", optional = true, default-features = false }
+reqwest-middleware = { version = "0.3.2", optional = true }
 http_typed_headers = { version = "0.1.0", path = "../http_typed_headers", default-features = false, features = ["accept", "location", "link"], optional = true }
-headers = { version = "0.3.9", optional = true }
+headers = { version = "0.4.0", optional = true }
 iref = { version = "2.2", optional = true }
 
 [features]
@@ -82,7 +82,7 @@ default = ["rdf-xml", "rustls-tls"]
 env_logger = "0.11.3"
 tracing = { version = "0.1.40", features = ["log"] }
 sophia_isomorphism = "0.8.0"
-rstest = "0.18.2"
+rstest = "0.21.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fcrates/rdf_dynsyn/src/parser/config/jsonld.rs
+++ b/fcrates/rdf_dynsyn/src/parser/config/jsonld.rs
@@ -36,12 +36,15 @@ where
     fn load(&mut self, url: ArcIri) -> LoaderFut<'_> {
         Box::pin(
             // See https://github.com/rust-lang/rust/issues/114447
-            Loader::<ArcIri, Location<ArcIri>>::load_with(self, unsafe { &mut *addr_of_mut!(VOC) }, url).map_err(
-                |e| {
-                    error!("Error in loading the document. {}", e);
-                    Box::new(e) as Box<DynDisplay>
-                },
-            ),
+            Loader::<ArcIri, Location<ArcIri>>::load_with(
+                self,
+                unsafe { &mut *addr_of_mut!(VOC) },
+                url,
+            )
+            .map_err(|e| {
+                error!("Error in loading the document. {}", e);
+                Box::new(e) as Box<DynDisplay>
+            }),
         )
     }
 }
@@ -500,10 +503,8 @@ mod http_loader {
                 let document = String::from_utf8(bytes.to_vec())
                     .map_err(JsonDocumentParseError::InvalidEncoding)
                     .and_then(|content| {
-                        Value::parse_str(&content, |span| {
-                            locspan::Location::new(uri.clone(), span)
-                        })
-                        .map_err(JsonDocumentParseError::Json)
+                        Value::parse_str(&content, |span| locspan::Location::new(uri.clone(), span))
+                            .map_err(JsonDocumentParseError::Json)
                     })
                     .map_err(|e| {
                         error!("Invalid document content. {}", e);

--- a/fcrates/rdf_dynsyn/src/parser/config/jsonld.rs
+++ b/fcrates/rdf_dynsyn/src/parser/config/jsonld.rs
@@ -1,7 +1,7 @@
 //! I define types to represent jsonld parser options.
 //!
 
-use std::{fmt::Display, sync::Arc};
+use std::{fmt::Display, ptr::addr_of_mut, sync::Arc};
 
 use futures::{future::BoxFuture, TryFutureExt};
 use json_ld::{syntax::Value, Loader, RemoteDocument};
@@ -24,6 +24,8 @@ trait _Loader: Send + Sync + 'static {
     fn load(&mut self, url: ArcIri) -> LoaderFut<'_>;
 }
 
+// The ArcVoc is unit struct without any state. But implements jsonld's
+// vocabulary traits. Hence safe for static mut.
 static mut VOC: ArcVoc = ArcVoc {};
 
 impl<L> _Loader for L
@@ -33,7 +35,8 @@ where
 {
     fn load(&mut self, url: ArcIri) -> LoaderFut<'_> {
         Box::pin(
-            Loader::<ArcIri, Location<ArcIri>>::load_with(self, unsafe { &mut VOC }, url).map_err(
+            // See https://github.com/rust-lang/rust/issues/114447
+            Loader::<ArcIri, Location<ArcIri>>::load_with(self, unsafe { &mut *addr_of_mut!(VOC) }, url).map_err(
                 |e| {
                     error!("Error in loading the document. {}", e);
                     Box::new(e) as Box<DynDisplay>
@@ -497,7 +500,7 @@ mod http_loader {
                 let document = String::from_utf8(bytes.to_vec())
                     .map_err(JsonDocumentParseError::InvalidEncoding)
                     .and_then(|content| {
-                        json_syntax::Value::parse_str(&content, |span| {
+                        Value::parse_str(&content, |span| {
                             locspan::Location::new(uri.clone(), span)
                         })
                         .map_err(JsonDocumentParseError::Json)

--- a/fcrates/rdf_dynsyn/src/parser/quads/source.rs
+++ b/fcrates/rdf_dynsyn/src/parser/quads/source.rs
@@ -3,8 +3,10 @@ use std::{error::Error, io::BufRead};
 use rio_api::parser::QuadsParser as RioQuadsParser;
 use rio_turtle::{NQuadsParser as RioNQuadsParser, TriGParser as RioTriGParser};
 use sophia_api::source::{QuadSource, StreamResult};
-use sophia_jsonld::JsonLdQuadSource;
 use sophia_rio::parser::StrictRioSource;
+
+#[cfg(feature = "jsonld")]
+use sophia_jsonld::JsonLdQuadSource;
 
 use crate::{model::DynSynQuad, parser::error::DynSynParseError};
 

--- a/fcrates/rdf_dynsyn/src/util/stream.rs
+++ b/fcrates/rdf_dynsyn/src/util/stream.rs
@@ -9,7 +9,7 @@ where
     S: TryStream<Ok = Bytes> + Send + 'static + Unpin,
     S::Error: 'static + Into<Box<dyn std::error::Error + Send + Sync>>,
 {
-    data.map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    data.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
         .into_async_read()
 }
 
@@ -32,7 +32,7 @@ impl<S: Stream + Unpin> BlockingStreamIterator<S> {
     #[inline]
     #[track_caller]
     pub fn new(stream: S) -> io::Result<Self> {
-        Self::new_with_handle(stream, tokio::runtime::Handle::current())
+        Self::new_with_handle(stream, Handle::current())
     }
 
     /// Get new [`BlockingStreamIterator`] backed by given stream, and given runtime handle.

--- a/fcrates/rdf_utils/Cargo.toml
+++ b/fcrates/rdf_utils/Cargo.toml
@@ -29,7 +29,7 @@ rio_api = { version = "0.8.4", optional = true, features = ["generalized"] }
 sophia_rio = { version = "0.8.0", optional = true }
 mime = { version = "0.3.17", optional = true }
 rand = { version = "0.8.5", optional = true }
-itertools = { version = "0.11.0", optional = true }
+itertools = { version = "0.13.0", optional = true }
 rio_turtle = { version = "0.8.4", optional = true, features = ["generalized"] }
 
 # feature: compat-chrono

--- a/fcrates/rdf_utils/Cargo.toml
+++ b/fcrates/rdf_utils/Cargo.toml
@@ -10,16 +10,16 @@ license = "MIT OR Apache-2.0"
 once_cell = "1.19.0"
 sophia_api = "0.8.0"
 tracing = { version = "0.1.40", features = ["attributes"] }
-thiserror = "1.0.56"
+thiserror = "1.0.61"
 unwrap-infallible = "0.1.5"
-paste = "1.0.14"
+paste = "1.0.15"
 
 # feature: query
 resiter = { version = "0.5.0", optional = true }
 
 # feature: solid-insert-delete-patch
-oxilangtag = { version = "0.1.3", optional = true }
-oxiri = { version = "0.2.2", optional = true }
+oxilangtag = { version = "0.1.5", optional = true }
+oxiri = { version = "0.2.3", optional = true }
 rdf_vocabularies = { version = "0.2.0", features = [
     "ns-xsd",
     "ns-rdf",
@@ -33,16 +33,16 @@ itertools = { version = "0.11.0", optional = true }
 rio_turtle = { version = "0.8.4", optional = true, features = ["generalized"] }
 
 # feature: compat-chrono
-chrono = { version = "0.4.33", optional = true, default-features = false, features = ["std"]}
+chrono = { version = "0.4.38", optional = true, default-features = false, features = ["std"]}
 
 # feature: compat-iri-string
-iri-string = { version = "0.7.0", optional = true }
+iri-string = { version = "0.7.2", optional = true }
 
 # feature: inmem
 sophia_inmem = { version = "0.8.0", optional = true }
 
 # feature: compat-ecow
-ecow = { version = "0.2.0", optional = true }
+ecow = { version = "0.2.2", optional = true }
 
 
 [features]

--- a/fcrates/rdf_utils/Cargo.toml
+++ b/fcrates/rdf_utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rdf_utils"
 version = "0.3.1"
+rust = "1.79.0"
 edition = "2021"
 description = "This crate provides utilities to deal with rdf data.."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/rdf_utils/src/query.rs
+++ b/fcrates/rdf_utils/src/query.rs
@@ -63,7 +63,7 @@ impl Query {
                             matcher(t.o(), initial_bindings),
                         ];
                         let hint = triples_matching(graph, &tm).size_hint();
-                        (hint.1.unwrap_or(std::usize::MAX), hint.0)
+                        (hint.1.unwrap_or(usize::MAX), hint.0)
                     })
                     .collect();
                 for i in 1..hints.len() {
@@ -134,7 +134,7 @@ fn bindings_for_triple<'a, G>(
 where
     G: Graph,
 {
-    let tm = vec![
+    let tm = [
         matcher(tq.s(), &b),
         matcher(tq.p(), &b),
         matcher(tq.o(), &b),

--- a/fcrates/rdf_utils/src/query.rs
+++ b/fcrates/rdf_utils/src/query.rs
@@ -126,6 +126,7 @@ where
 }
 
 /// Iter over the bindings of triple `tq` for graph `g`, given the binding `b`.
+#[allow(clippy::useless_vec)]
 fn bindings_for_triple<'a, G>(
     g: &'a G,
     tq: &'a [ArcTerm; 3],
@@ -134,7 +135,7 @@ fn bindings_for_triple<'a, G>(
 where
     G: Graph,
 {
-    let tm = [
+    let tm = vec![
         matcher(tq.s(), &b),
         matcher(tq.p(), &b),
         matcher(tq.o(), &b),

--- a/fcrates/solid_oidc_types/Cargo.toml
+++ b/fcrates/solid_oidc_types/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "solid_oidc_types"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "A crate with types representing concepts in solid-oidc specification."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/solid_oidc_types/Cargo.toml
+++ b/fcrates/solid_oidc_types/Cargo.toml
@@ -15,9 +15,9 @@ http_uri = { version = "1.0.1", path = "../http_uri", features = ["serde"] }
 picky = { version = "7.0.0-rc.8", default-features = false, features = [
     "jose",
 ] }
-serde = { version = "1.0.196", features = ["derive"] }
-serde_json = "1.0.113"
-thiserror = "1.0.56"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.120"
+thiserror = "1.0.61"
 tracing = { version = "0.1.40", features = ["attributes"] }
 webid = { version = "0.1.0", path = "../webid", features = ["serde"] }
 

--- a/fcrates/solid_oidc_types/src/id_token/payload.rs
+++ b/fcrates/solid_oidc_types/src/id_token/payload.rs
@@ -65,6 +65,7 @@ mod predicate {
 
     /// A predicate over [`SolidOidcIdTokenClaims`] that
     /// asserts for their validity.
+    #[allow(dead_code)]
     #[derive(Debug)]
     pub struct AreValidSolidOidcIdTokenClaims;
 

--- a/fcrates/typed_record/Cargo.toml
+++ b/fcrates/typed_record/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 anymap2 = { version = "0.13.0", optional = true }
 
 # feature: ext-http
-http = { version = "0.2.11", optional = true }
+http = { version = "0.2.12", optional = true }
 
 
 [features]

--- a/fcrates/typed_record/Cargo.toml
+++ b/fcrates/typed_record/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 anymap2 = { version = "0.13.0", optional = true }
 
 # feature: ext-http
-http = { version = "0.2.12", optional = true }
+http = { version = "1.1.0", optional = true }
 
 
 [features]

--- a/fcrates/typed_record/Cargo.toml
+++ b/fcrates/typed_record/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "typed_record"
 version = "0.1.1"
+rust = "1.79.0"
 edition = "2021"
 description = "Util trait for using typed extensions(like `http::Extensions`, `AnyMap`) as typed kv record."
 repository = "https://github.com/manomayam/manas"

--- a/fcrates/webid/Cargo.toml
+++ b/fcrates/webid/Cargo.toml
@@ -22,12 +22,12 @@ gdp_rs = { version = "0.1.1", path = "../gdp_rs", optional = true }
 sophia_api = { version = "0.8.0", optional = true }
 
 # feature: profile-req-agent
-reqwest = { version = "0.11.27", optional = true, features = ["stream"], default-features = false}
+reqwest = { version = "0.12.5", optional = true, features = ["stream"], default-features = false}
 tracing = { version = "0.1.40", features = ["attributes"] }
 rdf_dynsyn = { version = "0.4.0", path = "../rdf_dynsyn", optional = true, features = [
     "async",
 ] }
-headers = { version = "0.3.9", optional = true }
+headers = { version = "0.4.0", optional = true }
 mime = { version = "0.3.17", optional = true }
 futures = { version = "0.3.30", optional = true }
 

--- a/fcrates/webid/Cargo.toml
+++ b/fcrates/webid/Cargo.toml
@@ -9,11 +9,11 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 http_uri = { version = "1.0.1", path = "../http_uri", default-features = false, features = ["sophia"]}
-iri-string = "0.7.0"
-thiserror = "1.0.56"
+iri-string = "0.7.2"
+thiserror = "1.0.61"
 
 # feature: serde
-serde = { version = "1.0.196", features = ["derive"], optional = true }
+serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 # feature: invariant
 gdp_rs = { version = "0.1.1", path = "../gdp_rs", optional = true }
@@ -22,7 +22,7 @@ gdp_rs = { version = "0.1.1", path = "../gdp_rs", optional = true }
 sophia_api = { version = "0.8.0", optional = true }
 
 # feature: profile-req-agent
-reqwest = { version = "0.11.24", optional = true, features = ["stream"], default-features = false}
+reqwest = { version = "0.11.27", optional = true, features = ["stream"], default-features = false}
 tracing = { version = "0.1.40", features = ["attributes"] }
 rdf_dynsyn = { version = "0.4.0", path = "../rdf_dynsyn", optional = true, features = [
     "async",

--- a/fcrates/webid/Cargo.toml
+++ b/fcrates/webid/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "webid"
 version = "0.1.0"
+rust = "1.79.0"
 edition = "2021"
 description = "A crate for handling web-ids"
 repository = "https://github.com/manomayam/manas"
 license = "MIT OR Apache-2.0"
-
 
 [dependencies]
 http_uri = { version = "1.0.1", path = "../http_uri", default-features = false, features = ["sophia"]}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.79.0"
 components = [ "rustfmt", "clippy" ]
 


### PR DESCRIPTION
This PR contains following changes.

- Migrate to new hyper 1.0/http ecosystem. Handles all breaking changes.
- Cargo update compatible dependencies
- Refactor to leverage now stabilised [Associated type bounds](https://rust-lang.github.io/rfcs/2289-associated-type-bounds.html), and set MSRV to `1.79.0`.

Closes #52 